### PR TITLE
feat: Epic 3 - Measurement CRUD with automatic alert evaluation

### DIFF
--- a/app/Application/Measurement/CreateMeasurement/CreateMeasurementCommand.php
+++ b/app/Application/Measurement/CreateMeasurement/CreateMeasurementCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\CreateMeasurement;
+
+final class CreateMeasurementCommand
+{
+    public function __construct(
+        public readonly string $stationId,
+        public readonly float  $temperature,
+        public readonly float  $humidity,
+        public readonly float  $atmosphericPressure,
+        public readonly string $reportedAt,
+    ) {}
+}

--- a/app/Application/Measurement/CreateMeasurement/CreateMeasurementHandler.php
+++ b/app/Application/Measurement/CreateMeasurement/CreateMeasurementHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\CreateMeasurement;
+
+use App\Application\Measurement\MeasurementResponse;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use DateTimeImmutable;
+
+final class CreateMeasurementHandler
+{
+    public function __construct(
+        private readonly MeasurementRepository    $measurementRepository,
+        private readonly WeatherStationRepository $stationRepository,
+    ) {}
+
+    public function handle(CreateMeasurementCommand $command): MeasurementResponse
+    {
+        $stationId = StationId::fromString($command->stationId);
+
+        if ($this->stationRepository->findById($stationId) === null) {
+            throw new StationNotFoundException($command->stationId);
+        }
+
+        $measurement = Measurement::create(
+            MeasurementId::generate(),
+            $stationId,
+            new Temperature($command->temperature),
+            new Humidity($command->humidity),
+            new AtmosphericPressure($command->atmosphericPressure),
+            new DateTimeImmutable($command->reportedAt),
+        );
+
+        $this->measurementRepository->save($measurement);
+
+        return MeasurementResponse::fromEntity($measurement);
+    }
+}

--- a/app/Application/Measurement/DeleteMeasurement/DeleteMeasurementCommand.php
+++ b/app/Application/Measurement/DeleteMeasurement/DeleteMeasurementCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\DeleteMeasurement;
+
+final class DeleteMeasurementCommand
+{
+    public function __construct(
+        public readonly string $id,
+    ) {}
+}

--- a/app/Application/Measurement/DeleteMeasurement/DeleteMeasurementHandler.php
+++ b/app/Application/Measurement/DeleteMeasurement/DeleteMeasurementHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\DeleteMeasurement;
+
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+
+final class DeleteMeasurementHandler
+{
+    public function __construct(
+        private readonly MeasurementRepository $measurementRepository,
+    ) {}
+
+    public function handle(DeleteMeasurementCommand $command): void
+    {
+        $id = MeasurementId::fromString($command->id);
+
+        if ($this->measurementRepository->findById($id) === null) {
+            throw new MeasurementNotFoundException($command->id);
+        }
+
+        $this->measurementRepository->delete($id);
+    }
+}

--- a/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsHandler.php
+++ b/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\GetAllMeasurements;
+
+use App\Application\Measurement\MeasurementResponse;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+
+final class GetAllMeasurementsHandler
+{
+    public function __construct(
+        private readonly MeasurementRepository $measurementRepository,
+    ) {}
+
+    /** @return MeasurementResponse[] */
+    public function handle(GetAllMeasurementsQuery $query): array
+    {
+        return array_map(
+            fn(Measurement $m) => MeasurementResponse::fromEntity($m),
+            $this->measurementRepository->findAll(),
+        );
+    }
+}

--- a/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsQuery.php
+++ b/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsQuery.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\GetAllMeasurements;
+
+final class GetAllMeasurementsQuery {}

--- a/app/Application/Measurement/GetMeasurement/GetMeasurementHandler.php
+++ b/app/Application/Measurement/GetMeasurement/GetMeasurementHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\GetMeasurement;
+
+use App\Application\Measurement\MeasurementResponse;
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+
+final class GetMeasurementHandler
+{
+    public function __construct(
+        private readonly MeasurementRepository $measurementRepository,
+    ) {}
+
+    public function handle(GetMeasurementQuery $query): MeasurementResponse
+    {
+        $measurement = $this->measurementRepository->findById(
+            MeasurementId::fromString($query->id),
+        );
+
+        if ($measurement === null) {
+            throw new MeasurementNotFoundException($query->id);
+        }
+
+        return MeasurementResponse::fromEntity($measurement);
+    }
+}

--- a/app/Application/Measurement/GetMeasurement/GetMeasurementQuery.php
+++ b/app/Application/Measurement/GetMeasurement/GetMeasurementQuery.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\GetMeasurement;
+
+final class GetMeasurementQuery
+{
+    public function __construct(
+        public readonly string $id,
+    ) {}
+}

--- a/app/Application/Measurement/MeasurementResponse.php
+++ b/app/Application/Measurement/MeasurementResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement;
+
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Enums\AlertType;
+use DateTimeInterface;
+
+final class MeasurementResponse
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $stationId,
+        public readonly float  $temperature,
+        public readonly float  $humidity,
+        public readonly float  $atmosphericPressure,
+        public readonly string $reportedAt,
+        public readonly bool   $alertStatus,
+        /** @var string[] */
+        public readonly array  $alertTypes,
+    ) {}
+
+    public static function fromEntity(Measurement $measurement): self
+    {
+        return new self(
+            id:                  $measurement->id()->value(),
+            stationId:           $measurement->stationId()->value(),
+            temperature:         $measurement->temperature()->value(),
+            humidity:            $measurement->humidity()->value(),
+            atmosphericPressure: $measurement->atmosphericPressure()->value(),
+            reportedAt:          $measurement->reportedAt()->format(DateTimeInterface::ATOM),
+            alertStatus:         $measurement->alertStatus(),
+            alertTypes:          array_map(fn(AlertType $type) => $type->label(), $measurement->alertTypes()),
+        );
+    }
+}

--- a/app/Application/Measurement/UpdateMeasurement/UpdateMeasurementCommand.php
+++ b/app/Application/Measurement/UpdateMeasurement/UpdateMeasurementCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\UpdateMeasurement;
+
+final class UpdateMeasurementCommand
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly float  $temperature,
+        public readonly float  $humidity,
+        public readonly float  $atmosphericPressure,
+        public readonly string $reportedAt,
+    ) {}
+}

--- a/app/Application/Measurement/UpdateMeasurement/UpdateMeasurementHandler.php
+++ b/app/Application/Measurement/UpdateMeasurement/UpdateMeasurementHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Measurement\UpdateMeasurement;
+
+use App\Application\Measurement\MeasurementResponse;
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use DateTimeImmutable;
+
+final class UpdateMeasurementHandler
+{
+    public function __construct(
+        private readonly MeasurementRepository $measurementRepository,
+    ) {}
+
+    public function handle(UpdateMeasurementCommand $command): MeasurementResponse
+    {
+        $measurement = $this->measurementRepository->findById(
+            MeasurementId::fromString($command->id),
+        );
+
+        if ($measurement === null) {
+            throw new MeasurementNotFoundException($command->id);
+        }
+
+        $measurement->update(
+            new Temperature($command->temperature),
+            new Humidity($command->humidity),
+            new AtmosphericPressure($command->atmosphericPressure),
+            new DateTimeImmutable($command->reportedAt),
+        );
+
+        $this->measurementRepository->save($measurement);
+
+        return MeasurementResponse::fromEntity($measurement);
+    }
+}

--- a/app/Domain/Measurement/Entities/Measurement.php
+++ b/app/Domain/Measurement/Entities/Measurement.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\Entities;
+
+use App\Domain\Measurement\Enums\AlertType;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use DateTimeImmutable;
+
+final class Measurement
+{
+    private function __construct(
+        private readonly MeasurementId      $id,
+        private readonly StationId          $stationId,
+        private Temperature                 $temperature,
+        private Humidity                    $humidity,
+        private AtmosphericPressure         $atmosphericPressure,
+        private DateTimeImmutable           $reportedAt,
+        private bool                        $alertStatus,
+        /** @var AlertType[] */
+        private array                       $alertTypes,
+    ) {}
+
+    public static function create(
+        MeasurementId       $id,
+        StationId           $stationId,
+        Temperature         $temperature,
+        Humidity            $humidity,
+        AtmosphericPressure $atmosphericPressure,
+        DateTimeImmutable   $reportedAt,
+    ): self {
+        $alertTypes = AlertType::fromReadings($temperature, $humidity, $atmosphericPressure);
+
+        return new self(
+            $id,
+            $stationId,
+            $temperature,
+            $humidity,
+            $atmosphericPressure,
+            $reportedAt,
+            $alertTypes !== [AlertType::None],
+            $alertTypes,
+        );
+    }
+
+    public function update(
+        Temperature         $temperature,
+        Humidity            $humidity,
+        AtmosphericPressure $atmosphericPressure,
+        DateTimeImmutable   $reportedAt,
+    ): void {
+        $this->temperature         = $temperature;
+        $this->humidity            = $humidity;
+        $this->atmosphericPressure = $atmosphericPressure;
+        $this->reportedAt          = $reportedAt;
+
+        $alertTypes          = AlertType::fromReadings($temperature, $humidity, $atmosphericPressure);
+        $this->alertTypes    = $alertTypes;
+        $this->alertStatus   = $alertTypes !== [AlertType::None];
+    }
+
+    public function id(): MeasurementId
+    {
+        return $this->id;
+    }
+
+    public function stationId(): StationId
+    {
+        return $this->stationId;
+    }
+
+    public function temperature(): Temperature
+    {
+        return $this->temperature;
+    }
+
+    public function humidity(): Humidity
+    {
+        return $this->humidity;
+    }
+
+    public function atmosphericPressure(): AtmosphericPressure
+    {
+        return $this->atmosphericPressure;
+    }
+
+    public function reportedAt(): DateTimeImmutable
+    {
+        return $this->reportedAt;
+    }
+
+    public function alertStatus(): bool
+    {
+        return $this->alertStatus;
+    }
+
+    /** @return AlertType[] */
+    public function alertTypes(): array
+    {
+        return $this->alertTypes;
+    }
+}

--- a/app/Domain/Measurement/Enums/AlertType.php
+++ b/app/Domain/Measurement/Enums/AlertType.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\Enums;
+
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\Temperature;
+
+enum AlertType: string
+{
+    case None             = 'none';
+    case ExtremeHeat      = 'extreme_heat';
+    case Frost            = 'frost';
+    case Storm            = 'storm';
+    case CriticalHumidity = 'critical_humidity';
+
+    public function matches(Temperature $temperature, Humidity $humidity, AtmosphericPressure $pressure): bool
+    {
+        return match ($this) {
+            self::ExtremeHeat      => $temperature->value() > 40.0,
+            self::Frost            => $temperature->value() < 0.0,
+            self::Storm            => $pressure->value() < 980.0,
+            self::CriticalHumidity => $humidity->value() > 90.0,
+            self::None             => false,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::None             => 'None',
+            self::ExtremeHeat      => 'Extreme Heat',
+            self::Frost            => 'Frost',
+            self::Storm            => 'Storm',
+            self::CriticalHumidity => 'Critical Humidity',
+        };
+    }
+
+    /** @return self[] */
+    public static function fromReadings(
+        Temperature         $temperature,
+        Humidity            $humidity,
+        AtmosphericPressure $pressure,
+    ): array {
+        $alerts = array_values(array_filter(
+            self::cases(),
+            fn(self $type) => $type->matches($temperature, $humidity, $pressure),
+        ));
+
+        return empty($alerts) ? [self::None] : $alerts;
+    }
+}

--- a/app/Domain/Measurement/Exceptions/MeasurementNotFoundException.php
+++ b/app/Domain/Measurement/Exceptions/MeasurementNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\Exceptions;
+
+use RuntimeException;
+
+final class MeasurementNotFoundException extends RuntimeException
+{
+    public function __construct(string $measurementId)
+    {
+        parent::__construct("Measurement not found: '{$measurementId}'");
+    }
+}

--- a/app/Domain/Measurement/Repositories/MeasurementRepository.php
+++ b/app/Domain/Measurement/Repositories/MeasurementRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\Repositories;
+
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+
+interface MeasurementRepository
+{
+    public function save(Measurement $measurement): void;
+
+    public function findById(MeasurementId $id): ?Measurement;
+
+    public function findAll(): array;
+
+    public function delete(MeasurementId $id): void;
+}

--- a/app/Domain/Measurement/ValueObjects/AtmosphericPressure.php
+++ b/app/Domain/Measurement/ValueObjects/AtmosphericPressure.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\ValueObjects;
+
+final class AtmosphericPressure
+{
+    public function __construct(
+        private readonly float $value,
+    ) {}
+
+    public function value(): float
+    {
+        return $this->value;
+    }
+}

--- a/app/Domain/Measurement/ValueObjects/Humidity.php
+++ b/app/Domain/Measurement/ValueObjects/Humidity.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\ValueObjects;
+
+use InvalidArgumentException;
+
+final class Humidity
+{
+    public function __construct(
+        private readonly float $value,
+    ) {
+        if ($value < 0.0 || $value > 100.0) {
+            throw new InvalidArgumentException("Invalid humidity: '{$value}'. Must be between 0 and 100.");
+        }
+    }
+
+    public function value(): float
+    {
+        return $this->value;
+    }
+}

--- a/app/Domain/Measurement/ValueObjects/MeasurementId.php
+++ b/app/Domain/Measurement/ValueObjects/MeasurementId.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\ValueObjects;
+
+use InvalidArgumentException;
+use Ramsey\Uuid\Uuid;
+
+final class MeasurementId
+{
+    private function __construct(
+        private readonly string $value,
+    ) {}
+
+    public static function generate(): self
+    {
+        return new self(Uuid::uuid4()->toString());
+    }
+
+    public static function fromString(string $value): self
+    {
+        if (!Uuid::isValid($value)) {
+            throw new InvalidArgumentException("Invalid MeasurementId: '{$value}'");
+        }
+
+        return new self($value);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Domain/Measurement/ValueObjects/Temperature.php
+++ b/app/Domain/Measurement/ValueObjects/Temperature.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\ValueObjects;
+
+final class Temperature
+{
+    public function __construct(
+        private readonly float $value,
+    ) {}
+
+    public function value(): float
+    {
+        return $this->value;
+    }
+}

--- a/app/Infrastructure/Http/Controllers/MeasurementController.php
+++ b/app/Infrastructure/Http/Controllers/MeasurementController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Controllers;
+
+use App\Application\Measurement\CreateMeasurement\CreateMeasurementCommand;
+use App\Application\Measurement\CreateMeasurement\CreateMeasurementHandler;
+use App\Application\Measurement\DeleteMeasurement\DeleteMeasurementCommand;
+use App\Application\Measurement\DeleteMeasurement\DeleteMeasurementHandler;
+use App\Application\Measurement\GetAllMeasurements\GetAllMeasurementsHandler;
+use App\Application\Measurement\GetAllMeasurements\GetAllMeasurementsQuery;
+use App\Application\Measurement\GetMeasurement\GetMeasurementHandler;
+use App\Application\Measurement\GetMeasurement\GetMeasurementQuery;
+use App\Application\Measurement\UpdateMeasurement\UpdateMeasurementCommand;
+use App\Application\Measurement\UpdateMeasurement\UpdateMeasurementHandler;
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Infrastructure\Http\Requests\CreateMeasurementRequest;
+use App\Infrastructure\Http\Requests\UpdateMeasurementRequest;
+use Illuminate\Http\JsonResponse;
+
+final class MeasurementController
+{
+    public function __construct(
+        private readonly CreateMeasurementHandler    $createHandler,
+        private readonly GetMeasurementHandler       $getHandler,
+        private readonly GetAllMeasurementsHandler   $getAllHandler,
+        private readonly UpdateMeasurementHandler    $updateHandler,
+        private readonly DeleteMeasurementHandler    $deleteHandler,
+    ) {}
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->getAllHandler->handle(new GetAllMeasurementsQuery()));
+    }
+
+    public function show(string $id): JsonResponse
+    {
+        try {
+            return response()->json($this->getHandler->handle(new GetMeasurementQuery($id)));
+        } catch (MeasurementNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+
+    public function store(CreateMeasurementRequest $request): JsonResponse
+    {
+        try {
+            $measurement = $this->createHandler->handle(new CreateMeasurementCommand(
+                stationId:           $request->input('station_id'),
+                temperature:         (float) $request->input('temperature'),
+                humidity:            (float) $request->input('humidity'),
+                atmosphericPressure: (float) $request->input('atmospheric_pressure'),
+                reportedAt:          $request->input('reported_at'),
+            ));
+
+            return response()->json($measurement, 201);
+        } catch (StationNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+    }
+
+    public function update(UpdateMeasurementRequest $request, string $id): JsonResponse
+    {
+        try {
+            $measurement = $this->updateHandler->handle(new UpdateMeasurementCommand(
+                id:                  $id,
+                temperature:         (float) $request->input('temperature'),
+                humidity:            (float) $request->input('humidity'),
+                atmosphericPressure: (float) $request->input('atmospheric_pressure'),
+                reportedAt:          $request->input('reported_at'),
+            ));
+
+            return response()->json($measurement);
+        } catch (MeasurementNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+
+    public function destroy(string $id): JsonResponse
+    {
+        try {
+            $this->deleteHandler->handle(new DeleteMeasurementCommand($id));
+
+            return response()->json(null, 204);
+        } catch (MeasurementNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+}

--- a/app/Infrastructure/Http/Requests/CreateMeasurementRequest.php
+++ b/app/Infrastructure/Http/Requests/CreateMeasurementRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateMeasurementRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'station_id'           => ['required', 'string', 'uuid'],
+            'temperature'          => ['required', 'numeric'],
+            'humidity'             => ['required', 'numeric', 'between:0,100'],
+            'atmospheric_pressure' => ['required', 'numeric'],
+            'reported_at'          => ['required', 'date'],
+        ];
+    }
+}

--- a/app/Infrastructure/Http/Requests/UpdateMeasurementRequest.php
+++ b/app/Infrastructure/Http/Requests/UpdateMeasurementRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateMeasurementRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'temperature'          => ['required', 'numeric'],
+            'humidity'             => ['required', 'numeric', 'between:0,100'],
+            'atmospheric_pressure' => ['required', 'numeric'],
+            'reported_at'          => ['required', 'date'],
+        ];
+    }
+}

--- a/app/Infrastructure/Persistence/MongoDB/MeasurementModel.php
+++ b/app/Infrastructure/Persistence/MongoDB/MeasurementModel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\MongoDB;
+
+final class MeasurementModel extends BaseMongoModel
+{
+    protected $table = 'measurements';
+    protected $primaryKey = '_id';
+
+    protected $fillable = [
+        '_id',
+        'station_id',
+        'temperature',
+        'humidity',
+        'atmospheric_pressure',
+        'reported_at',
+        'alert_status',
+        'alert_types',
+    ];
+
+    protected $casts = [
+        'temperature'          => 'float',
+        'humidity'             => 'float',
+        'atmospheric_pressure' => 'float',
+        'alert_status'         => 'boolean',
+        'alert_types'          => 'array',
+    ];
+}

--- a/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
+++ b/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\MongoDB;
+
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Enums\AlertType;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+final class MongoMeasurementRepository implements MeasurementRepository
+{
+    public function save(Measurement $measurement): void
+    {
+        MeasurementModel::updateOrCreate(
+            ['_id' => $measurement->id()->value()],
+            [
+                'station_id'           => $measurement->stationId()->value(),
+                'temperature'          => $measurement->temperature()->value(),
+                'humidity'             => $measurement->humidity()->value(),
+                'atmospheric_pressure' => $measurement->atmosphericPressure()->value(),
+                'reported_at'          => $measurement->reportedAt()->format(DateTimeInterface::ATOM),
+                'alert_status'         => $measurement->alertStatus(),
+                'alert_types'          => array_map(fn(AlertType $t) => $t->value, $measurement->alertTypes()),
+            ]
+        );
+    }
+
+    public function findById(MeasurementId $id): ?Measurement
+    {
+        $model = MeasurementModel::find($id->value());
+
+        return $model ? $this->toDomain($model) : null;
+    }
+
+    public function findAll(): array
+    {
+        return MeasurementModel::all()
+            ->map(fn(MeasurementModel $model) => $this->toDomain($model))
+            ->all();
+    }
+
+    public function delete(MeasurementId $id): void
+    {
+        MeasurementModel::destroy($id->value());
+    }
+
+    private function toDomain(MeasurementModel $model): Measurement
+    {
+        return Measurement::create(
+            MeasurementId::fromString($model->_id),
+            StationId::fromString($model->station_id),
+            new Temperature($model->temperature),
+            new Humidity($model->humidity),
+            new AtmosphericPressure($model->atmospheric_pressure),
+            new DateTimeImmutable($model->reported_at),
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Domain\Measurement\Repositories\MeasurementRepository;
 use App\Domain\User\Repositories\UserRepository;
 use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
+use App\Infrastructure\Persistence\MongoDB\MongoMeasurementRepository;
 use App\Infrastructure\Persistence\MongoDB\MongoUserRepository;
 use App\Infrastructure\Persistence\MongoDB\MongoWeatherStationRepository;
 use Illuminate\Support\ServiceProvider;
@@ -16,6 +18,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->bind(UserRepository::class, MongoUserRepository::class);
         $this->app->bind(WeatherStationRepository::class, MongoWeatherStationRepository::class);
+        $this->app->bind(MeasurementRepository::class, MongoMeasurementRepository::class);
     }
 
     public function boot(): void {}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Infrastructure\Http\Controllers\MeasurementController;
 use App\Infrastructure\Http\Controllers\UserController;
 use App\Infrastructure\Http\Controllers\WeatherStationController;
 use Illuminate\Support\Facades\Route;
 
 Route::apiResource('users', UserController::class);
 Route::apiResource('stations', WeatherStationController::class);
+Route::apiResource('measurements', MeasurementController::class);

--- a/tests/Feature/Measurement/MeasurementApiTest.php
+++ b/tests/Feature/Measurement/MeasurementApiTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Feature\RefreshMongoCollections;
+
+uses(RefreshMongoCollections::class);
+
+beforeEach(function () {
+    $this->collectionsToClean = ['measurements', 'weather_stations', 'users'];
+    $this->cleanCollections();
+});
+
+function createOwner($test): string
+{
+    return $test->postJson('/api/users', [
+        'email'      => 'owner@example.com',
+        'first_name' => 'Owner',
+        'last_name'  => 'User',
+    ])->json('id');
+}
+
+function createStation($test, string $ownerId): string
+{
+    return $test->postJson('/api/stations', [
+        'owner_id'     => $ownerId,
+        'station_name' => 'Estación Central',
+        'latitude'     => -34.6037,
+        'longitude'    => -58.3816,
+        'sensor_model' => 'Davis Vantage Pro2',
+    ])->json('id');
+}
+
+function measurementPayload(string $stationId, array $overrides = []): array
+{
+    return array_merge([
+        'station_id'           => $stationId,
+        'temperature'          => 25.0,
+        'humidity'             => 60.0,
+        'atmospheric_pressure' => 1013.0,
+        'reported_at'          => '2026-04-06T14:30:00Z',
+    ], $overrides);
+}
+
+// -------------------------------------------------------------------------
+// POST /api/measurements
+// -------------------------------------------------------------------------
+
+test('creates a measurement and returns 201', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId))
+        ->assertStatus(201)
+        ->assertJsonStructure(['id', 'stationId', 'temperature', 'humidity', 'atmosphericPressure', 'reportedAt', 'alertStatus', 'alertTypes'])
+        ->assertJsonFragment([
+            'alertStatus' => false,
+            'alertTypes'  => ['None'],
+        ]);
+});
+
+test('returns 422 when station does not exist', function () {
+    $this->postJson('/api/measurements', measurementPayload('00000000-0000-4000-a000-000000000000'))
+        ->assertStatus(422);
+});
+
+test('returns 422 when required fields are missing', function () {
+    $this->postJson('/api/measurements', [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['station_id', 'temperature', 'humidity', 'atmospheric_pressure', 'reported_at']);
+});
+
+test('returns 422 when humidity is out of range', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['humidity' => 150.0]))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['humidity']);
+});
+
+test('creates measurement with extreme heat alert', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 41.0]))
+        ->assertStatus(201)
+        ->assertJsonFragment([
+            'alertStatus' => true,
+            'alertTypes'  => ['Extreme Heat'],
+        ]);
+});
+
+test('creates measurement with frost alert', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => -1.0]))
+        ->assertStatus(201)
+        ->assertJsonFragment([
+            'alertStatus' => true,
+            'alertTypes'  => ['Frost'],
+        ]);
+});
+
+test('creates measurement with storm alert', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['atmospheric_pressure' => 979.0]))
+        ->assertStatus(201)
+        ->assertJsonFragment([
+            'alertStatus' => true,
+            'alertTypes'  => ['Storm'],
+        ]);
+});
+
+test('creates measurement with critical humidity alert', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['humidity' => 91.0]))
+        ->assertStatus(201)
+        ->assertJsonFragment([
+            'alertStatus' => true,
+            'alertTypes'  => ['Critical Humidity'],
+        ]);
+});
+
+test('creates measurement with multiple simultaneous alerts', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $response = $this->postJson('/api/measurements', measurementPayload($stationId, [
+        'temperature' => -5.0,
+        'humidity'    => 95.0,
+    ]))->assertStatus(201);
+
+    expect($response->json('alertStatus'))->toBeTrue()
+        ->and($response->json('alertTypes'))->toContain('Frost')
+        ->and($response->json('alertTypes'))->toContain('Critical Humidity');
+});
+
+// -------------------------------------------------------------------------
+// GET /api/measurements/{id}
+// -------------------------------------------------------------------------
+
+test('returns a measurement by id', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $created = $this->postJson('/api/measurements', measurementPayload($stationId))->json();
+
+    $this->getJson("/api/measurements/{$created['id']}")
+        ->assertStatus(200)
+        ->assertJsonFragment(['id' => $created['id']]);
+});
+
+test('returns 404 when measurement does not exist', function () {
+    $this->getJson('/api/measurements/00000000-0000-4000-a000-000000000000')
+        ->assertStatus(404);
+});
+
+// -------------------------------------------------------------------------
+// GET /api/measurements
+// -------------------------------------------------------------------------
+
+test('returns all measurements', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 30.0]));
+
+    $this->getJson('/api/measurements')
+        ->assertStatus(200)
+        ->assertJsonCount(2);
+});
+
+// -------------------------------------------------------------------------
+// PUT /api/measurements/{id}
+// -------------------------------------------------------------------------
+
+test('updates a measurement and recalculates alerts', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $created = $this->postJson('/api/measurements', measurementPayload($stationId))->json();
+
+    $this->putJson("/api/measurements/{$created['id']}", [
+        'temperature'          => 41.0,
+        'humidity'             => 50.0,
+        'atmospheric_pressure' => 1013.0,
+        'reported_at'          => '2026-04-07T10:00:00Z',
+    ])->assertStatus(200)
+        ->assertJsonFragment([
+            'alertStatus' => true,
+            'alertTypes'  => ['Extreme Heat'],
+        ]);
+});
+
+test('returns 404 when updating nonexistent measurement', function () {
+    $this->putJson('/api/measurements/00000000-0000-4000-a000-000000000000', [
+        'temperature'          => 20.0,
+        'humidity'             => 50.0,
+        'atmospheric_pressure' => 1013.0,
+        'reported_at'          => '2026-04-07T10:00:00Z',
+    ])->assertStatus(404);
+});
+
+// -------------------------------------------------------------------------
+// DELETE /api/measurements/{id}
+// -------------------------------------------------------------------------
+
+test('deletes a measurement and returns 204', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $created = $this->postJson('/api/measurements', measurementPayload($stationId))->json();
+
+    $this->deleteJson("/api/measurements/{$created['id']}")->assertStatus(204);
+    $this->getJson("/api/measurements/{$created['id']}")->assertStatus(404);
+});
+
+test('returns 404 when deleting nonexistent measurement', function () {
+    $this->deleteJson('/api/measurements/00000000-0000-4000-a000-000000000000')
+        ->assertStatus(404);
+});

--- a/tests/Unit/Application/Measurement/CreateMeasurementHandlerTest.php
+++ b/tests/Unit/Application/Measurement/CreateMeasurementHandlerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Measurement\CreateMeasurement\CreateMeasurementCommand;
+use App\Application\Measurement\CreateMeasurement\CreateMeasurementHandler;
+use App\Application\Measurement\MeasurementResponse;
+use App\Domain\Measurement\Enums\AlertType;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Enums\StationStatus;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+function makeStation(): WeatherStation
+{
+    return WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(-34.6037, -58.3816),
+        'Davis Vantage Pro2',
+        StationStatus::Active,
+    );
+}
+
+function makeCreateCommand(string $stationId, float $temp = 20.0, float $humidity = 50.0, float $pressure = 1013.0): CreateMeasurementCommand
+{
+    return new CreateMeasurementCommand(
+        stationId:           $stationId,
+        temperature:         $temp,
+        humidity:            $humidity,
+        atmosphericPressure: $pressure,
+        reportedAt:          '2026-04-01T12:00:00Z',
+    );
+}
+
+test('creates a measurement and returns a response', function () {
+    $station = makeStation();
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    $handler = new CreateMeasurementHandler(new FakeMeasurementRepository(), $stationRepo);
+    $response = $handler->handle(makeCreateCommand($station->id()->value()));
+
+    expect($response)->toBeInstanceOf(MeasurementResponse::class)
+        ->and($response->stationId)->toBe($station->id()->value())
+        ->and($response->temperature)->toBe(20.0)
+        ->and($response->alertStatus)->toBeFalse()
+        ->and($response->alertTypes)->toBe(['None']);
+});
+
+test('calculates extreme heat alert on creation', function () {
+    $station = makeStation();
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    $handler = new CreateMeasurementHandler(new FakeMeasurementRepository(), $stationRepo);
+    $response = $handler->handle(makeCreateCommand($station->id()->value(), temp: 41.0));
+
+    expect($response->alertStatus)->toBeTrue()
+        ->and($response->alertTypes)->toBe(['Extreme Heat']);
+});
+
+test('calculates multiple alerts simultaneously on creation', function () {
+    $station = makeStation();
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    $handler = new CreateMeasurementHandler(new FakeMeasurementRepository(), $stationRepo);
+    $response = $handler->handle(makeCreateCommand($station->id()->value(), temp: -5.0, humidity: 95.0));
+
+    expect($response->alertStatus)->toBeTrue()
+        ->and($response->alertTypes)->toContain('Frost')
+        ->and($response->alertTypes)->toContain('Critical Humidity');
+});
+
+test('throws when station does not exist', function () {
+    $handler = new CreateMeasurementHandler(
+        new FakeMeasurementRepository(),
+        new FakeWeatherStationRepository(),
+    );
+
+    $handler->handle(makeCreateCommand('00000000-0000-4000-a000-000000000000'));
+})->throws(StationNotFoundException::class);

--- a/tests/Unit/Application/Measurement/DeleteMeasurementHandlerTest.php
+++ b/tests/Unit/Application/Measurement/DeleteMeasurementHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Measurement\DeleteMeasurement\DeleteMeasurementCommand;
+use App\Application\Measurement\DeleteMeasurement\DeleteMeasurementHandler;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+
+test('deletes an existing measurement', function () {
+    $repo = new FakeMeasurementRepository();
+    $measurement = Measurement::create(
+        MeasurementId::generate(),
+        StationId::generate(),
+        new Temperature(20.0),
+        new Humidity(50.0),
+        new AtmosphericPressure(1013.0),
+        new \DateTimeImmutable(),
+    );
+    $repo->seed($measurement);
+
+    (new DeleteMeasurementHandler($repo))->handle(new DeleteMeasurementCommand($measurement->id()->value()));
+
+    expect($repo->findById($measurement->id()))->toBeNull();
+});
+
+test('throws when measurement does not exist', function () {
+    (new DeleteMeasurementHandler(new FakeMeasurementRepository()))->handle(
+        new DeleteMeasurementCommand('00000000-0000-4000-a000-000000000000'),
+    );
+})->throws(MeasurementNotFoundException::class);

--- a/tests/Unit/Application/Measurement/GetAllMeasurementsHandlerTest.php
+++ b/tests/Unit/Application/Measurement/GetAllMeasurementsHandlerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Measurement\GetAllMeasurements\GetAllMeasurementsHandler;
+use App\Application\Measurement\GetAllMeasurements\GetAllMeasurementsQuery;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+
+test('returns all measurements', function () {
+    $repo = new FakeMeasurementRepository();
+    $repo->seed(
+        Measurement::create(MeasurementId::generate(), StationId::generate(), new Temperature(20.0), new Humidity(50.0), new AtmosphericPressure(1013.0), new \DateTimeImmutable()),
+        Measurement::create(MeasurementId::generate(), StationId::generate(), new Temperature(25.0), new Humidity(60.0), new AtmosphericPressure(1010.0), new \DateTimeImmutable()),
+    );
+
+    $result = (new GetAllMeasurementsHandler($repo))->handle(new GetAllMeasurementsQuery());
+
+    expect($result)->toHaveCount(2);
+});
+
+test('returns empty array when no measurements exist', function () {
+    $result = (new GetAllMeasurementsHandler(new FakeMeasurementRepository()))->handle(new GetAllMeasurementsQuery());
+
+    expect($result)->toBeEmpty();
+});

--- a/tests/Unit/Application/Measurement/GetMeasurementHandlerTest.php
+++ b/tests/Unit/Application/Measurement/GetMeasurementHandlerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Measurement\GetMeasurement\GetMeasurementHandler;
+use App\Application\Measurement\GetMeasurement\GetMeasurementQuery;
+use App\Application\Measurement\MeasurementResponse;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+
+function makeSeededMeasurement(): Measurement
+{
+    return Measurement::create(
+        MeasurementId::generate(),
+        StationId::generate(),
+        new Temperature(20.0),
+        new Humidity(50.0),
+        new AtmosphericPressure(1013.0),
+        new \DateTimeImmutable('2026-04-01T12:00:00Z'),
+    );
+}
+
+test('returns a measurement by id', function () {
+    $repo = new FakeMeasurementRepository();
+    $measurement = makeSeededMeasurement();
+    $repo->seed($measurement);
+
+    $handler = new GetMeasurementHandler($repo);
+    $response = $handler->handle(new GetMeasurementQuery($measurement->id()->value()));
+
+    expect($response)->toBeInstanceOf(MeasurementResponse::class)
+        ->and($response->id)->toBe($measurement->id()->value());
+});
+
+test('throws when measurement does not exist', function () {
+    $handler = new GetMeasurementHandler(new FakeMeasurementRepository());
+
+    $handler->handle(new GetMeasurementQuery('00000000-0000-4000-a000-000000000000'));
+})->throws(MeasurementNotFoundException::class);

--- a/tests/Unit/Application/Measurement/UpdateMeasurementHandlerTest.php
+++ b/tests/Unit/Application/Measurement/UpdateMeasurementHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Measurement\UpdateMeasurement\UpdateMeasurementCommand;
+use App\Application\Measurement\UpdateMeasurement\UpdateMeasurementHandler;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+
+function makeUpdateCommand(string $id, float $temp = 20.0, float $humidity = 50.0, float $pressure = 1013.0): UpdateMeasurementCommand
+{
+    return new UpdateMeasurementCommand(
+        id:                  $id,
+        temperature:         $temp,
+        humidity:            $humidity,
+        atmosphericPressure: $pressure,
+        reportedAt:          '2026-04-02T12:00:00Z',
+    );
+}
+
+test('updates a measurement and recalculates alerts', function () {
+    $repo = new FakeMeasurementRepository();
+    $measurement = Measurement::create(
+        MeasurementId::generate(),
+        StationId::generate(),
+        new Temperature(20.0),
+        new Humidity(50.0),
+        new AtmosphericPressure(1013.0),
+        new \DateTimeImmutable('2026-04-01T12:00:00Z'),
+    );
+    $repo->seed($measurement);
+
+    $response = (new UpdateMeasurementHandler($repo))->handle(
+        makeUpdateCommand($measurement->id()->value(), temp: 41.0),
+    );
+
+    expect($response->temperature)->toBe(41.0)
+        ->and($response->alertStatus)->toBeTrue()
+        ->and($response->alertTypes)->toContain('Extreme Heat');
+});
+
+test('throws when measurement does not exist', function () {
+    (new UpdateMeasurementHandler(new FakeMeasurementRepository()))->handle(
+        makeUpdateCommand('00000000-0000-4000-a000-000000000000'),
+    );
+})->throws(MeasurementNotFoundException::class);

--- a/tests/Unit/Application/WeatherStation/CreateStationHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/CreateStationHandlerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\WeatherStation\CreateStation\CreateStationCommand;
+use App\Application\WeatherStation\CreateStation\CreateStationHandler;
+use App\Application\WeatherStation\StationResponse;
+use App\Domain\User\Entities\User;
+use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\User\ValueObjects\Email;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Enums\StationStatus;
+use Tests\Unit\Domain\User\FakeUserRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+function makeUser(): User
+{
+    return User::create(UserId::generate(), new Email('owner@example.com'), 'Owner', 'User');
+}
+
+function makeCreateStationCommand(string $ownerId, ?string $status = null): CreateStationCommand
+{
+    return new CreateStationCommand(
+        ownerId:     $ownerId,
+        stationName: 'Estación Central',
+        latitude:    -34.6037,
+        longitude:   -58.3816,
+        sensorModel: 'Davis Vantage Pro2',
+        status:      $status,
+    );
+}
+
+test('creates a station and returns a response', function () {
+    $user = makeUser();
+    $userRepo = new FakeUserRepository();
+    $userRepo->seed($user);
+
+    $response = (new CreateStationHandler(new FakeWeatherStationRepository(), $userRepo))
+        ->handle(makeCreateStationCommand($user->id()->value()));
+
+    expect($response)->toBeInstanceOf(StationResponse::class)
+        ->and($response->ownerId)->toBe($user->id()->value())
+        ->and($response->stationName)->toBe('Estación Central')
+        ->and($response->status)->toBe('active');
+});
+
+test('defaults status to active', function () {
+    $user = makeUser();
+    $userRepo = new FakeUserRepository();
+    $userRepo->seed($user);
+
+    $response = (new CreateStationHandler(new FakeWeatherStationRepository(), $userRepo))
+        ->handle(makeCreateStationCommand($user->id()->value()));
+
+    expect($response->status)->toBe(StationStatus::Active->value);
+});
+
+test('throws when owner does not exist', function () {
+    (new CreateStationHandler(new FakeWeatherStationRepository(), new FakeUserRepository()))
+        ->handle(makeCreateStationCommand('00000000-0000-4000-a000-000000000000'));
+})->throws(UserNotFoundException::class);

--- a/tests/Unit/Application/WeatherStation/DeleteStationHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/DeleteStationHandlerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\WeatherStation\DeleteStation\DeleteStationCommand;
+use App\Application\WeatherStation\DeleteStation\DeleteStationHandler;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+test('deletes an existing station', function () {
+    $repo = new FakeWeatherStationRepository();
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(0.0, 0.0),
+        'Sensor X',
+    );
+    $repo->seed($station);
+
+    (new DeleteStationHandler($repo))->handle(new DeleteStationCommand($station->id()->value()));
+
+    expect($repo->findById($station->id()))->toBeNull();
+});
+
+test('throws when station does not exist', function () {
+    (new DeleteStationHandler(new FakeWeatherStationRepository()))
+        ->handle(new DeleteStationCommand('00000000-0000-4000-a000-000000000000'));
+})->throws(StationNotFoundException::class);

--- a/tests/Unit/Application/WeatherStation/GetAllStationsHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/GetAllStationsHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\WeatherStation\GetAllStations\GetAllStationsHandler;
+use App\Application\WeatherStation\GetAllStations\GetAllStationsQuery;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+test('returns all stations', function () {
+    $repo = new FakeWeatherStationRepository();
+    $ownerId = UserId::fromString('00000000-0000-4000-a000-000000000001');
+    $repo->seed(
+        WeatherStation::create(StationId::generate(), $ownerId, 'Estación A', new Location(0.0, 0.0), 'Sensor 1'),
+        WeatherStation::create(StationId::generate(), $ownerId, 'Estación B', new Location(1.0, 1.0), 'Sensor 2'),
+    );
+
+    $result = (new GetAllStationsHandler($repo))->handle(new GetAllStationsQuery());
+
+    expect($result)->toHaveCount(2);
+});
+
+test('returns empty array when no stations exist', function () {
+    $result = (new GetAllStationsHandler(new FakeWeatherStationRepository()))->handle(new GetAllStationsQuery());
+
+    expect($result)->toBeEmpty();
+});

--- a/tests/Unit/Application/WeatherStation/GetStationHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/GetStationHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\WeatherStation\GetStation\GetStationHandler;
+use App\Application\WeatherStation\GetStation\GetStationQuery;
+use App\Application\WeatherStation\StationResponse;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+function makeStation(): WeatherStation
+{
+    return WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(-34.6037, -58.3816),
+        'Davis Vantage Pro2',
+    );
+}
+
+test('returns a station by id', function () {
+    $repo = new FakeWeatherStationRepository();
+    $station = makeStation();
+    $repo->seed($station);
+
+    $response = (new GetStationHandler($repo))->handle(new GetStationQuery($station->id()->value()));
+
+    expect($response)->toBeInstanceOf(StationResponse::class)
+        ->and($response->id)->toBe($station->id()->value());
+});
+
+test('throws when station does not exist', function () {
+    (new GetStationHandler(new FakeWeatherStationRepository()))
+        ->handle(new GetStationQuery('00000000-0000-4000-a000-000000000000'));
+})->throws(StationNotFoundException::class);

--- a/tests/Unit/Application/WeatherStation/UpdateStationHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/UpdateStationHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\WeatherStation\UpdateStation\UpdateStationCommand;
+use App\Application\WeatherStation\UpdateStation\UpdateStationHandler;
+use App\Domain\User\Entities\User;
+use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\User\ValueObjects\Email;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\User\FakeUserRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+function makeUpdateStationCommand(string $stationId, string $ownerId): UpdateStationCommand
+{
+    return new UpdateStationCommand(
+        id:          $stationId,
+        ownerId:     $ownerId,
+        stationName: 'Estación Actualizada',
+        latitude:    0.0,
+        longitude:   0.0,
+        sensorModel: 'Sensor Nuevo',
+        status:      'inactive',
+    );
+}
+
+test('updates a station and returns the updated response', function () {
+    $user = User::create(UserId::generate(), new Email('owner@example.com'), 'Owner', 'User');
+    $station = WeatherStation::create(StationId::generate(), $user->id(), 'Estación Central', new Location(-34.6, -58.3), 'Sensor X');
+
+    $userRepo = new FakeUserRepository();
+    $userRepo->seed($user);
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    $response = (new UpdateStationHandler($stationRepo, $userRepo))
+        ->handle(makeUpdateStationCommand($station->id()->value(), $user->id()->value()));
+
+    expect($response->stationName)->toBe('Estación Actualizada')
+        ->and($response->sensorModel)->toBe('Sensor Nuevo')
+        ->and($response->status)->toBe('inactive');
+});
+
+test('throws when station does not exist', function () {
+    $user = User::create(UserId::generate(), new Email('owner@example.com'), 'Owner', 'User');
+    $userRepo = new FakeUserRepository();
+    $userRepo->seed($user);
+
+    (new UpdateStationHandler(new FakeWeatherStationRepository(), $userRepo))
+        ->handle(makeUpdateStationCommand('00000000-0000-4000-a000-000000000000', $user->id()->value()));
+})->throws(StationNotFoundException::class);
+
+test('throws when new owner does not exist', function () {
+    $user = User::create(UserId::generate(), new Email('owner@example.com'), 'Owner', 'User');
+    $station = WeatherStation::create(StationId::generate(), $user->id(), 'Estación Central', new Location(0.0, 0.0), 'Sensor X');
+
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    (new UpdateStationHandler($stationRepo, new FakeUserRepository()))
+        ->handle(makeUpdateStationCommand($station->id()->value(), '00000000-0000-4000-a000-000000000000'));
+})->throws(UserNotFoundException::class);

--- a/tests/Unit/Domain/Measurement/Entities/MeasurementTest.php
+++ b/tests/Unit/Domain/Measurement/Entities/MeasurementTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Measurement\Enums\AlertType;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+
+function makeMeasurement(float $temp = 20.0, float $humidity = 50.0, float $pressure = 1013.0): Measurement
+{
+    return Measurement::create(
+        MeasurementId::generate(),
+        StationId::generate(),
+        new Temperature($temp),
+        new Humidity($humidity),
+        new AtmosphericPressure($pressure),
+        new \DateTimeImmutable('2026-04-01T12:00:00Z'),
+    );
+}
+
+test('creates measurement with correct data', function () {
+    $measurement = makeMeasurement();
+
+    expect($measurement->temperature()->value())->toBe(20.0)
+        ->and($measurement->humidity()->value())->toBe(50.0)
+        ->and($measurement->atmosphericPressure()->value())->toBe(1013.0)
+        ->and($measurement->id())->toBeInstanceOf(MeasurementId::class);
+});
+
+test('has no alert for normal readings', function () {
+    $measurement = makeMeasurement();
+
+    expect($measurement->alertStatus())->toBeFalse()
+        ->and($measurement->alertTypes())->toBe([AlertType::None]);
+});
+
+test('has alert status true when any alert is active', function () {
+    $measurement = makeMeasurement(temp: 41.0);
+
+    expect($measurement->alertStatus())->toBeTrue();
+});
+
+test('updates measurement and recalculates alerts', function () {
+    $measurement = makeMeasurement();
+
+    $measurement->update(
+        new Temperature(41.0),
+        new Humidity(50.0),
+        new AtmosphericPressure(1013.0),
+        new \DateTimeImmutable('2026-04-02T12:00:00Z'),
+    );
+
+    expect($measurement->temperature()->value())->toBe(41.0)
+        ->and($measurement->alertStatus())->toBeTrue()
+        ->and($measurement->alertTypes())->toContain(AlertType::ExtremeHeat);
+});
+
+test('alert clears after update to normal readings', function () {
+    $measurement = makeMeasurement(temp: 41.0);
+
+    $measurement->update(
+        new Temperature(20.0),
+        new Humidity(50.0),
+        new AtmosphericPressure(1013.0),
+        new \DateTimeImmutable('2026-04-02T12:00:00Z'),
+    );
+
+    expect($measurement->alertStatus())->toBeFalse()
+        ->and($measurement->alertTypes())->toBe([AlertType::None]);
+});

--- a/tests/Unit/Domain/Measurement/Enums/AlertTypeTest.php
+++ b/tests/Unit/Domain/Measurement/Enums/AlertTypeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Measurement\Enums\AlertType;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\Temperature;
+
+// -------------------------------------------------------------------------
+// Alert detection
+// -------------------------------------------------------------------------
+
+test('detects extreme heat when temperature is above 40', function () {
+    $alerts = AlertType::fromReadings(new Temperature(40.1), new Humidity(50.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toContain(AlertType::ExtremeHeat);
+});
+
+test('does not trigger extreme heat at exactly 40', function () {
+    $alerts = AlertType::fromReadings(new Temperature(40.0), new Humidity(50.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toBe([AlertType::None]);
+});
+
+test('detects frost when temperature is below 0', function () {
+    $alerts = AlertType::fromReadings(new Temperature(-0.1), new Humidity(50.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toContain(AlertType::Frost);
+});
+
+test('does not trigger frost at exactly 0', function () {
+    $alerts = AlertType::fromReadings(new Temperature(0.0), new Humidity(50.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toBe([AlertType::None]);
+});
+
+test('detects storm when pressure is below 980', function () {
+    $alerts = AlertType::fromReadings(new Temperature(20.0), new Humidity(50.0), new AtmosphericPressure(979.9));
+
+    expect($alerts)->toContain(AlertType::Storm);
+});
+
+test('does not trigger storm at exactly 980', function () {
+    $alerts = AlertType::fromReadings(new Temperature(20.0), new Humidity(50.0), new AtmosphericPressure(980.0));
+
+    expect($alerts)->toBe([AlertType::None]);
+});
+
+test('detects critical humidity when humidity is above 90', function () {
+    $alerts = AlertType::fromReadings(new Temperature(20.0), new Humidity(90.1), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toContain(AlertType::CriticalHumidity);
+});
+
+test('does not trigger critical humidity at exactly 90', function () {
+    $alerts = AlertType::fromReadings(new Temperature(20.0), new Humidity(90.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toBe([AlertType::None]);
+});
+
+test('returns none when no conditions are met', function () {
+    $alerts = AlertType::fromReadings(new Temperature(20.0), new Humidity(50.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)->toBe([AlertType::None]);
+});
+
+// -------------------------------------------------------------------------
+// Multiple simultaneous alerts
+// -------------------------------------------------------------------------
+
+test('detects frost and critical humidity simultaneously', function () {
+    $alerts = AlertType::fromReadings(new Temperature(-5.0), new Humidity(95.0), new AtmosphericPressure(1013.0));
+
+    expect($alerts)
+        ->toContain(AlertType::Frost)
+        ->toContain(AlertType::CriticalHumidity)
+        ->not->toContain(AlertType::None);
+});
+
+test('detects storm and critical humidity simultaneously', function () {
+    $alerts = AlertType::fromReadings(new Temperature(20.0), new Humidity(95.0), new AtmosphericPressure(950.0));
+
+    expect($alerts)
+        ->toContain(AlertType::Storm)
+        ->toContain(AlertType::CriticalHumidity);
+});
+
+// -------------------------------------------------------------------------
+// Labels
+// -------------------------------------------------------------------------
+
+test('each alert type returns the correct label', function () {
+    expect(AlertType::None->label())->toBe('None')
+        ->and(AlertType::ExtremeHeat->label())->toBe('Extreme Heat')
+        ->and(AlertType::Frost->label())->toBe('Frost')
+        ->and(AlertType::Storm->label())->toBe('Storm')
+        ->and(AlertType::CriticalHumidity->label())->toBe('Critical Humidity');
+});

--- a/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
+++ b/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Measurement;
+
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+
+final class FakeMeasurementRepository implements MeasurementRepository
+{
+    /** @var Measurement[] */
+    private array $measurements = [];
+
+    public function save(Measurement $measurement): void
+    {
+        $this->measurements[$measurement->id()->value()] = $measurement;
+    }
+
+    public function findById(MeasurementId $id): ?Measurement
+    {
+        return $this->measurements[$id->value()] ?? null;
+    }
+
+    public function findAll(): array
+    {
+        return array_values($this->measurements);
+    }
+
+    public function delete(MeasurementId $id): void
+    {
+        unset($this->measurements[$id->value()]);
+    }
+
+    public function seed(Measurement ...$measurements): void
+    {
+        foreach ($measurements as $measurement) {
+            $this->measurements[$measurement->id()->value()] = $measurement;
+        }
+    }
+}


### PR DESCRIPTION
- En Domain se agrego
  - MeasurementId, Temperature, Humidity,AtmosphericPressure
  - AlertType enum con matches(), label() y fromReadings()
  - Measurement entity con create() y update()
  - MeasurementRepository interface  yMeasurementNotFoundException

  - En Application se agrego
    - CRUD completo: Create, Get, GetAll, Update, Delete handlers con commands/queries
    - MeasurementResponse DTO con alertTypes como labels legibles

  - En Infrastructure
    - MeasurementModel, MongoMeasurementRepository
    - MeasurementController con los 5 endpoints
    - Binding registrado en AppServiceProvider
    - Rutas en api.php

  - Se testearon todas las capas y a su vez se agregaron tests para la capa de aplicacion de las Estaciones.