### PR TITLE
feat: Epic 4 - Measurement history with filters

### DIFF
--- a/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsHandler.php
+++ b/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsHandler.php
@@ -6,20 +6,49 @@ namespace App\Application\Measurement\GetAllMeasurements;
 
 use App\Application\Measurement\MeasurementResponse;
 use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\Enums\AlertType;
 use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\MeasurementFilters;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
 
 final class GetAllMeasurementsHandler
 {
     public function __construct(
-        private readonly MeasurementRepository $measurementRepository,
+        private readonly MeasurementRepository    $measurementRepository,
+        private readonly WeatherStationRepository $weatherStationRepository,
     ) {}
 
     /** @return MeasurementResponse[] */
     public function handle(GetAllMeasurementsQuery $query): array
     {
-        return array_map(
-            fn(Measurement $m) => MeasurementResponse::fromEntity($m),
-            $this->measurementRepository->findAll(),
+        $filters = new MeasurementFilters(
+            stationIds: $this->resolveStationIds($query->stationName),
+            tempMin:    $query->tempMin,
+            tempMax:    $query->tempMax,
+            alertOnly:  $query->alertOnly,
+            alertType:  $query->alertType !== null ? AlertType::from($query->alertType) : null,
         );
+
+        return array_map(
+            fn(Measurement $measurement) => MeasurementResponse::fromEntity($measurement),
+            $this->measurementRepository->findAll($filters),
+        );
+    }
+
+    /** @return string[]|null */
+    private function resolveStationIds(?string $stationName): ?array
+    {
+        if ($stationName === null) {
+            return null;
+        }
+
+        return array_values(array_map(
+            fn(WeatherStation $station) => $station->id()->value(),
+            array_filter(
+                $this->weatherStationRepository->findAll(),
+                fn(WeatherStation $station) => stripos($station->stationName(), $stationName) !== false,
+            ),
+        ));
     }
 }

--- a/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsQuery.php
+++ b/app/Application/Measurement/GetAllMeasurements/GetAllMeasurementsQuery.php
@@ -4,4 +4,13 @@ declare(strict_types=1);
 
 namespace App\Application\Measurement\GetAllMeasurements;
 
-final class GetAllMeasurementsQuery {}
+final class GetAllMeasurementsQuery
+{
+    public function __construct(
+        public readonly ?string $stationName = null,
+        public readonly ?float  $tempMin     = null,
+        public readonly ?float  $tempMax     = null,
+        public readonly ?bool   $alertOnly   = null,
+        public readonly ?string $alertType   = null,
+    ) {}
+}

--- a/app/Domain/Measurement/Repositories/MeasurementRepository.php
+++ b/app/Domain/Measurement/Repositories/MeasurementRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Measurement\Repositories;
 
 use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\ValueObjects\MeasurementFilters;
 use App\Domain\Measurement\ValueObjects\MeasurementId;
 
 interface MeasurementRepository
@@ -13,7 +14,7 @@ interface MeasurementRepository
 
     public function findById(MeasurementId $id): ?Measurement;
 
-    public function findAll(): array;
+    public function findAll(MeasurementFilters $filters = new MeasurementFilters()): array;
 
     public function delete(MeasurementId $id): void;
 }

--- a/app/Domain/Measurement/ValueObjects/MeasurementFilters.php
+++ b/app/Domain/Measurement/ValueObjects/MeasurementFilters.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Measurement\ValueObjects;
+
+use App\Domain\Measurement\Enums\AlertType;
+
+final class MeasurementFilters
+{
+    /**
+     * @param string[]|null $stationIds  null = no filter; empty array = no stations matched (force empty result)
+     */
+    public function __construct(
+        private readonly ?array $stationIds = null,
+        private readonly ?float $tempMin = null,
+        private readonly ?float $tempMax = null,
+        private readonly ?bool $alertOnly = null,
+        private readonly ?AlertType $alertType = null,
+    ) {}
+
+    /** @return string[]|null */
+    public function stationIds(): ?array
+    {
+        return $this->stationIds;
+    }
+
+    public function tempMin(): ?float
+    {
+        return $this->tempMin;
+    }
+
+    public function tempMax(): ?float
+    {
+        return $this->tempMax;
+    }
+
+    public function alertOnly(): ?bool
+    {
+        return $this->alertOnly;
+    }
+
+    public function alertType(): ?AlertType
+    {
+        return $this->alertType;
+    }
+}

--- a/app/Infrastructure/Http/Controllers/MeasurementController.php
+++ b/app/Infrastructure/Http/Controllers/MeasurementController.php
@@ -17,6 +17,7 @@ use App\Application\Measurement\UpdateMeasurement\UpdateMeasurementHandler;
 use App\Domain\Measurement\Exceptions\MeasurementNotFoundException;
 use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
 use App\Infrastructure\Http\Requests\CreateMeasurementRequest;
+use App\Infrastructure\Http\Requests\GetMeasurementsRequest;
 use App\Infrastructure\Http\Requests\UpdateMeasurementRequest;
 use Illuminate\Http\JsonResponse;
 
@@ -30,9 +31,15 @@ final class MeasurementController
         private readonly DeleteMeasurementHandler    $deleteHandler,
     ) {}
 
-    public function index(): JsonResponse
+    public function index(GetMeasurementsRequest $request): JsonResponse
     {
-        return response()->json($this->getAllHandler->handle(new GetAllMeasurementsQuery()));
+        return response()->json($this->getAllHandler->handle(new GetAllMeasurementsQuery(
+            stationName: $request->input('station'),
+            tempMin:     $request->filled('temp_min') ? (float) $request->input('temp_min') : null,
+            tempMax:     $request->filled('temp_max') ? (float) $request->input('temp_max') : null,
+            alertOnly:   $request->has('alert') ? $request->boolean('alert') : null,
+            alertType:   $request->input('alert_type'),
+        )));
     }
 
     public function show(string $id): JsonResponse

--- a/app/Infrastructure/Http/Requests/GetMeasurementsRequest.php
+++ b/app/Infrastructure/Http/Requests/GetMeasurementsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Requests;
+
+use App\Domain\Measurement\Enums\AlertType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class GetMeasurementsRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'station'    => ['sometimes', 'string'],
+            'temp_min'   => ['sometimes', 'numeric'],
+            'temp_max'   => ['sometimes', 'numeric'],
+            'alert'      => ['sometimes', Rule::in(['true', 'false', '1', '0'])],
+            'alert_type' => ['sometimes', 'string', Rule::in(array_column(AlertType::cases(), 'value'))],
+        ];
+    }
+}

--- a/app/Infrastructure/Persistence/MongoDB/MeasurementModel.php
+++ b/app/Infrastructure/Persistence/MongoDB/MeasurementModel.php
@@ -25,6 +25,5 @@ final class MeasurementModel extends BaseMongoModel
         'humidity'             => 'float',
         'atmospheric_pressure' => 'float',
         'alert_status'         => 'boolean',
-        'alert_types'          => 'array',
     ];
 }

--- a/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
+++ b/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
@@ -9,6 +9,7 @@ use App\Domain\Measurement\Enums\AlertType;
 use App\Domain\Measurement\Repositories\MeasurementRepository;
 use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
 use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementFilters;
 use App\Domain\Measurement\ValueObjects\MeasurementId;
 use App\Domain\Measurement\ValueObjects\Temperature;
 use App\Domain\WeatherStation\ValueObjects\StationId;
@@ -40,9 +41,15 @@ final class MongoMeasurementRepository implements MeasurementRepository
         return $model ? $this->toDomain($model) : null;
     }
 
-    public function findAll(): array
+    public function findAll(MeasurementFilters $filters = new MeasurementFilters()): array
     {
-        return MeasurementModel::all()
+        return MeasurementModel::query()
+            ->when($filters->stationIds() !== null, fn($query) => $query->whereIn('station_id', $filters->stationIds() ?? []))
+            ->when($filters->tempMin()    !== null, fn($query) => $query->where('temperature', '>=', $filters->tempMin()))
+            ->when($filters->tempMax()    !== null, fn($query) => $query->where('temperature', '<=', $filters->tempMax()))
+            ->when($filters->alertOnly()  !== null, fn($query) => $query->where('alert_status', $filters->alertOnly()))
+            ->when($filters->alertType()  !== null, fn($query) => $query->where('alert_types', 'all', [$filters->alertType()->value]))
+            ->get()
             ->map(fn(MeasurementModel $model) => $this->toDomain($model))
             ->all();
     }

--- a/tests/Feature/Measurement/MeasurementApiTest.php
+++ b/tests/Feature/Measurement/MeasurementApiTest.php
@@ -157,13 +157,119 @@ test('returns 404 when measurement does not exist', function () {
 // GET /api/measurements
 // -------------------------------------------------------------------------
 
-test('returns all measurements', function () {
+test('returns all measurements when no filters are provided', function () {
     $stationId = createStation($this, createOwner($this));
 
     $this->postJson('/api/measurements', measurementPayload($stationId));
     $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 30.0]));
 
     $this->getJson('/api/measurements')
+        ->assertStatus(200)
+        ->assertJsonCount(2);
+});
+
+test('filters measurements by station name', function () {
+    $ownerId          = createOwner($this);
+    $centralStationId = createStation($this, $ownerId);
+    $northStationId   = $this->postJson('/api/stations', [
+        'owner_id'     => $ownerId,
+        'station_name' => 'Estación Norte',
+        'latitude'     => -34.5,
+        'longitude'    => -58.4,
+        'sensor_model' => 'Davis Vantage Pro2',
+    ])->json('id');
+
+    $this->postJson('/api/measurements', measurementPayload($centralStationId));
+    $this->postJson('/api/measurements', measurementPayload($northStationId));
+
+    $this->getJson('/api/measurements?station=Central')
+        ->assertStatus(200)
+        ->assertJsonCount(1);
+});
+
+test('returns empty when station name matches no stations', function () {
+    $stationId = createStation($this, createOwner($this));
+    $this->postJson('/api/measurements', measurementPayload($stationId));
+
+    $this->getJson('/api/measurements?station=Inexistente')
+        ->assertStatus(200)
+        ->assertJsonCount(0);
+});
+
+test('filters measurements by minimum temperature', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 10.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 30.0]));
+
+    $this->getJson('/api/measurements?temp_min=20')
+        ->assertStatus(200)
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['temperature' => 30.0]);
+});
+
+test('filters measurements by maximum temperature', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 10.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 30.0]));
+
+    $this->getJson('/api/measurements?temp_max=20')
+        ->assertStatus(200)
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['temperature' => 10.0]);
+});
+
+test('filters only alert measurements', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 20.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 41.0]));
+
+    $this->getJson('/api/measurements?alert=true')
+        ->assertStatus(200)
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['alertStatus' => true]);
+});
+
+test('filters only non-alert measurements', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 20.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 41.0]));
+
+    $this->getJson('/api/measurements?alert=false')
+        ->assertStatus(200)
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['alertStatus' => false]);
+});
+
+test('filters measurements by specific alert type', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 41.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => -1.0]));
+
+    $this->getJson('/api/measurements?alert_type=extreme_heat')
+        ->assertStatus(200)
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['temperature' => 41.0]);
+});
+
+test('returns 422 when alert_type is invalid', function () {
+    $this->getJson('/api/measurements?alert_type=invalid_type')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['alert_type']);
+});
+
+test('combines multiple filters correctly', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 10.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 41.0]));
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['temperature' => 45.0]));
+
+    $this->getJson('/api/measurements?temp_min=40&alert=true')
         ->assertStatus(200)
         ->assertJsonCount(2);
 });

--- a/tests/Unit/Application/Measurement/GetAllMeasurementsHandlerTest.php
+++ b/tests/Unit/Application/Measurement/GetAllMeasurementsHandlerTest.php
@@ -9,23 +9,200 @@ use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
 use App\Domain\Measurement\ValueObjects\Humidity;
 use App\Domain\Measurement\ValueObjects\MeasurementId;
 use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Enums\StationStatus;
+use App\Domain\WeatherStation\ValueObjects\Location;
 use App\Domain\WeatherStation\ValueObjects\StationId;
 use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
 
-test('returns all measurements', function () {
-    $repo = new FakeMeasurementRepository();
-    $repo->seed(
-        Measurement::create(MeasurementId::generate(), StationId::generate(), new Temperature(20.0), new Humidity(50.0), new AtmosphericPressure(1013.0), new \DateTimeImmutable()),
-        Measurement::create(MeasurementId::generate(), StationId::generate(), new Temperature(25.0), new Humidity(60.0), new AtmosphericPressure(1010.0), new \DateTimeImmutable()),
+function makeHandler(FakeMeasurementRepository $measurementRepo, FakeWeatherStationRepository $stationRepo): GetAllMeasurementsHandler
+{
+    return new GetAllMeasurementsHandler($measurementRepo, $stationRepo);
+}
+
+function makeMeasurementForHandler(StationId $stationId, float $temp = 20.0, float $humidity = 50.0, float $pressure = 1013.0): Measurement
+{
+    return Measurement::create(
+        MeasurementId::generate(),
+        $stationId,
+        new Temperature($temp),
+        new Humidity($humidity),
+        new AtmosphericPressure($pressure),
+        new \DateTimeImmutable(),
+    );
+}
+
+function makeStationWithName(string $name = 'Estación Central'): WeatherStation
+{
+    return WeatherStation::create(
+        StationId::generate(),
+        UserId::generate(),
+        $name,
+        new Location(-34.6037, -58.3816),
+        'Davis Vantage Pro2',
+        StationStatus::Active,
+    );
+}
+
+// -------------------------------------------------------------------------
+// No filters
+// -------------------------------------------------------------------------
+
+test('returns all measurements when no filters are provided', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId),
+        makeMeasurementForHandler($stationId, temp: 30.0),
     );
 
-    $result = (new GetAllMeasurementsHandler($repo))->handle(new GetAllMeasurementsQuery());
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery());
 
     expect($result)->toHaveCount(2);
 });
 
 test('returns empty array when no measurements exist', function () {
-    $result = (new GetAllMeasurementsHandler(new FakeMeasurementRepository()))->handle(new GetAllMeasurementsQuery());
+    $result = makeHandler(new FakeMeasurementRepository(), new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery());
 
     expect($result)->toBeEmpty();
+});
+
+// -------------------------------------------------------------------------
+// Station name filter
+// -------------------------------------------------------------------------
+
+test('filters measurements by station name', function () {
+    $stationRepo     = new FakeWeatherStationRepository();
+    $measurementRepo = new FakeMeasurementRepository();
+
+    $matchingStation = makeStationWithName('Estación Central');
+    $otherStation    = makeStationWithName('Estación Norte');
+    $stationRepo->seed($matchingStation, $otherStation);
+
+    $measurementRepo->seed(
+        makeMeasurementForHandler($matchingStation->id()),
+        makeMeasurementForHandler($otherStation->id()),
+    );
+
+    $result = makeHandler($measurementRepo, $stationRepo)
+        ->handle(new GetAllMeasurementsQuery(stationName: 'Central'));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->stationId)->toBe($matchingStation->id()->value());
+});
+
+test('returns empty when station name matches no stations', function () {
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed(makeStationWithName('Estación Central'));
+
+    $measurementRepo = new FakeMeasurementRepository();
+    $measurementRepo->seed(makeMeasurementForHandler(StationId::generate()));
+
+    $result = makeHandler($measurementRepo, $stationRepo)
+        ->handle(new GetAllMeasurementsQuery(stationName: 'Inexistente'));
+
+    expect($result)->toBeEmpty();
+});
+
+// -------------------------------------------------------------------------
+// Temperature filters
+// -------------------------------------------------------------------------
+
+test('filters measurements by minimum temperature', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId, temp: 10.0),
+        makeMeasurementForHandler($stationId, temp: 30.0),
+    );
+
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery(tempMin: 20.0));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->temperature)->toBe(30.0);
+});
+
+test('filters measurements by maximum temperature', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId, temp: 10.0),
+        makeMeasurementForHandler($stationId, temp: 30.0),
+    );
+
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery(tempMax: 20.0));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->temperature)->toBe(10.0);
+});
+
+test('filters measurements by temperature range', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId, temp: 5.0),
+        makeMeasurementForHandler($stationId, temp: 20.0),
+        makeMeasurementForHandler($stationId, temp: 40.0),
+    );
+
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery(tempMin: 10.0, tempMax: 35.0));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->temperature)->toBe(20.0);
+});
+
+// -------------------------------------------------------------------------
+// Alert filters
+// -------------------------------------------------------------------------
+
+test('filters only alert measurements when alertOnly is true', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId, temp: 20.0),
+        makeMeasurementForHandler($stationId, temp: 41.0),
+    );
+
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery(alertOnly: true));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->alertStatus)->toBeTrue();
+});
+
+test('filters only non-alert measurements when alertOnly is false', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId, temp: 20.0),
+        makeMeasurementForHandler($stationId, temp: 41.0),
+    );
+
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery(alertOnly: false));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->alertStatus)->toBeFalse();
+});
+
+test('filters measurements by specific alert type', function () {
+    $measurementRepo = new FakeMeasurementRepository();
+    $stationId       = StationId::generate();
+    $measurementRepo->seed(
+        makeMeasurementForHandler($stationId, temp: 41.0),
+        makeMeasurementForHandler($stationId, temp: -1.0),
+    );
+
+    $result = makeHandler($measurementRepo, new FakeWeatherStationRepository())
+        ->handle(new GetAllMeasurementsQuery(alertType: 'extreme_heat'));
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->temperature)->toBe(41.0);
 });

--- a/tests/Unit/Application/WeatherStation/GetStationHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/GetStationHandlerTest.php
@@ -12,7 +12,7 @@ use App\Domain\WeatherStation\ValueObjects\Location;
 use App\Domain\WeatherStation\ValueObjects\StationId;
 use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
 
-function makeStation(): WeatherStation
+function makeWeatherStation(): WeatherStation
 {
     return WeatherStation::create(
         StationId::generate(),
@@ -25,7 +25,7 @@ function makeStation(): WeatherStation
 
 test('returns a station by id', function () {
     $repo = new FakeWeatherStationRepository();
-    $station = makeStation();
+    $station = makeWeatherStation();
     $repo->seed($station);
 
     $response = (new GetStationHandler($repo))->handle(new GetStationQuery($station->id()->value()));

--- a/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
+++ b/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Domain\Measurement;
 
 use App\Domain\Measurement\Entities\Measurement;
 use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\Measurement\ValueObjects\MeasurementFilters;
 use App\Domain\Measurement\ValueObjects\MeasurementId;
 
 final class FakeMeasurementRepository implements MeasurementRepository
@@ -23,9 +24,12 @@ final class FakeMeasurementRepository implements MeasurementRepository
         return $this->measurements[$id->value()] ?? null;
     }
 
-    public function findAll(): array
+    public function findAll(MeasurementFilters $filters = new MeasurementFilters()): array
     {
-        return array_values($this->measurements);
+        return array_values(array_filter(
+            $this->measurements,
+            fn(Measurement $measurement) => $this->matchesFilters($measurement, $filters),
+        ));
     }
 
     public function delete(MeasurementId $id): void
@@ -38,5 +42,14 @@ final class FakeMeasurementRepository implements MeasurementRepository
         foreach ($measurements as $measurement) {
             $this->measurements[$measurement->id()->value()] = $measurement;
         }
+    }
+
+    private function matchesFilters(Measurement $measurement, MeasurementFilters $filters): bool
+    {
+        return ($filters->stationIds() === null || in_array($measurement->stationId()->value(), $filters->stationIds(), true))
+            && ($filters->tempMin()    === null || $measurement->temperature()->value() >= $filters->tempMin())
+            && ($filters->tempMax()    === null || $measurement->temperature()->value() <= $filters->tempMax())
+            && ($filters->alertOnly()  === null || $measurement->alertStatus() === $filters->alertOnly())
+            && ($filters->alertType()  === null || in_array($filters->alertType(), $measurement->alertTypes(), true));
     }
 }


### PR DESCRIPTION
-  Se agregó la posibilidad de filtrar el listado de mediciones por nombre de estación, rango de temperatura, estado de alerta y tipo de alerta específico. Todos los filtros son opcionales e independientes entre sí — sin parámetros, el endpoint devuelve todas las mediciones como antes.