### PR TITLE
feat: Epic 5 - User subscriptions to weather stations

### DIFF
--- a/app/Application/User/AbstractUserHandler.php
+++ b/app/Application/User/AbstractUserHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User;
+
+use App\Domain\User\Entities\User;
+use App\Domain\User\Repositories\UserRepository;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
+
+abstract class AbstractUserHandler
+{
+    public function __construct(
+        protected readonly UserRepository           $userRepository,
+        protected readonly WeatherStationRepository $stationRepository,
+    ) {}
+
+    /** @return array<string, WeatherStation> */
+    protected function resolveSubscribedStationsById(User $user): array
+    {
+        $subscribedStationsById = [];
+
+        foreach ($this->stationRepository->findByIds($user->subscriptions()) as $station) {
+            $subscribedStationsById[$station->id()->value()] = $station;
+        }
+
+        return $subscribedStationsById;
+    }
+}

--- a/app/Application/User/GetAllUsers/GetAllUsersHandler.php
+++ b/app/Application/User/GetAllUsers/GetAllUsersHandler.php
@@ -4,23 +4,18 @@ declare(strict_types=1);
 
 namespace App\Application\User\GetAllUsers;
 
-use App\Application\User\UserResponse;
-use App\Domain\User\Repositories\UserRepository;
+use App\Application\User\AbstractUserHandler;
+use App\Application\User\UserResponseWithSubscriptions;
+use App\Domain\User\Entities\User;
 
-final class GetAllUsersHandler
+final class GetAllUsersHandler extends AbstractUserHandler
 {
-    public function __construct(
-        private readonly UserRepository $userRepository,
-    ) {}
-
-    /** @return UserResponse[] */
+    /** @return UserResponseWithSubscriptions[] */
     public function handle(GetAllUsersQuery $query): array
     {
-        $users = $this->userRepository->findAll();
-
         return array_map(
-            fn ($user) => UserResponse::fromEntity($user),
-            $users,
+            fn (User $user) => UserResponseWithSubscriptions::fromEntity($user, $this->resolveSubscribedStationsById($user)),
+            $this->userRepository->findAll(),
         );
     }
 }

--- a/app/Application/User/GetUser/GetUserHandler.php
+++ b/app/Application/User/GetUser/GetUserHandler.php
@@ -4,18 +4,14 @@ declare(strict_types=1);
 
 namespace App\Application\User\GetUser;
 
-use App\Application\User\UserResponse;
+use App\Application\User\AbstractUserHandler;
+use App\Application\User\UserResponseWithSubscriptions;
 use App\Domain\User\Exceptions\UserNotFoundException;
-use App\Domain\User\Repositories\UserRepository;
 use App\Domain\User\ValueObjects\UserId;
 
-final class GetUserHandler
+final class GetUserHandler extends AbstractUserHandler
 {
-    public function __construct(
-        private readonly UserRepository $userRepository,
-    ) {}
-
-    public function handle(GetUserQuery $query): UserResponse
+    public function handle(GetUserQuery $query): UserResponseWithSubscriptions
     {
         $user = $this->userRepository->findById(UserId::fromString($query->id));
 
@@ -23,6 +19,6 @@ final class GetUserHandler
             throw new UserNotFoundException($query->id);
         }
 
-        return UserResponse::fromEntity($user);
+        return UserResponseWithSubscriptions::fromEntity($user, $this->resolveSubscribedStationsById($user));
     }
 }

--- a/app/Application/User/SubscribeUserToStation/SubscribeUserToStationCommand.php
+++ b/app/Application/User/SubscribeUserToStation/SubscribeUserToStationCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\SubscribeUserToStation;
+
+final class SubscribeUserToStationCommand
+{
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $stationId,
+    ) {}
+}

--- a/app/Application/User/SubscribeUserToStation/SubscribeUserToStationHandler.php
+++ b/app/Application/User/SubscribeUserToStation/SubscribeUserToStationHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\SubscribeUserToStation;
+
+use App\Application\User\AbstractUserHandler;
+use App\Application\User\UserResponseWithSubscriptions;
+use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+
+final class SubscribeUserToStationHandler extends AbstractUserHandler
+{
+    public function handle(SubscribeUserToStationCommand $command): UserResponseWithSubscriptions
+    {
+        $userId    = UserId::fromString($command->userId);
+        $stationId = StationId::fromString($command->stationId);
+
+        $user = $this->userRepository->findById($userId);
+        if ($user === null) {
+            throw new UserNotFoundException($command->userId);
+        }
+
+        if ($this->stationRepository->findById($stationId) === null) {
+            throw new StationNotFoundException($command->stationId);
+        }
+
+        $user->subscribe($stationId);
+        $this->userRepository->save($user);
+
+        return UserResponseWithSubscriptions::fromEntity($user, $this->resolveSubscribedStationsById($user));
+    }
+}

--- a/app/Application/User/SubscriptionResponse.php
+++ b/app/Application/User/SubscriptionResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User;
+
+use App\Domain\WeatherStation\Entities\WeatherStation;
+
+final class SubscriptionResponse
+{
+    public function __construct(
+        public readonly string $stationId,
+        public readonly string $name,
+        public readonly float  $latitude,
+        public readonly float  $longitude,
+        public readonly string $sensorModel,
+        public readonly string $status,
+    ) {}
+
+    public static function fromStation(WeatherStation $station): self
+    {
+        return new self(
+            stationId:   $station->id()->value(),
+            name:        $station->stationName(),
+            latitude:    $station->location()->latitude(),
+            longitude:   $station->location()->longitude(),
+            sensorModel: $station->sensorModel(),
+            status:      $station->status()->value,
+        );
+    }
+}

--- a/app/Application/User/UnsubscribeUserFromStation/UnsubscribeUserFromStationCommand.php
+++ b/app/Application/User/UnsubscribeUserFromStation/UnsubscribeUserFromStationCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\UnsubscribeUserFromStation;
+
+final class UnsubscribeUserFromStationCommand
+{
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $stationId,
+    ) {}
+}

--- a/app/Application/User/UnsubscribeUserFromStation/UnsubscribeUserFromStationHandler.php
+++ b/app/Application/User/UnsubscribeUserFromStation/UnsubscribeUserFromStationHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\UnsubscribeUserFromStation;
+
+use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\User\Repositories\UserRepository;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+
+final class UnsubscribeUserFromStationHandler
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+    ) {}
+
+    public function handle(UnsubscribeUserFromStationCommand $command): void
+    {
+        $userId    = UserId::fromString($command->userId);
+        $stationId = StationId::fromString($command->stationId);
+
+        $user = $this->userRepository->findById($userId);
+        if ($user === null) {
+            throw new UserNotFoundException($command->userId);
+        }
+
+        $user->unsubscribe($stationId);
+        $this->userRepository->save($user);
+    }
+}

--- a/app/Application/User/UpdateUser/UpdateUserHandler.php
+++ b/app/Application/User/UpdateUser/UpdateUserHandler.php
@@ -20,7 +20,7 @@ final class UpdateUserHandler
     public function handle(UpdateUserCommand $command): UserResponse
     {
         $userId = UserId::fromString($command->id);
-        $user = $this->userRepository->findById($userId);
+        $user   = $this->userRepository->findById($userId);
 
         if ($user === null) {
             throw new UserNotFoundException($command->id);

--- a/app/Application/User/UserResponseWithSubscriptions.php
+++ b/app/Application/User/UserResponseWithSubscriptions.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User;
+
+use App\Domain\User\Entities\User;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+
+final class UserResponseWithSubscriptions
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $email,
+        public readonly string $firstName,
+        public readonly string $lastName,
+        public readonly array  $subscriptions,
+    ) {}
+
+    /**
+     * @param array<string, WeatherStation> $subscribedStationsById
+     */
+    public static function fromEntity(User $user, array $subscribedStationsById): self
+    {
+        $subscriptions = [];
+        foreach ($user->subscriptions() as $stationId) {
+            $station = $subscribedStationsById[$stationId->value()] ?? null;
+            if ($station !== null) {
+                $subscriptions[] = SubscriptionResponse::fromStation($station);
+            }
+        }
+
+        return new self(
+            id:            $user->id()->value(),
+            email:         $user->email()->value(),
+            firstName:     $user->firstName(),
+            lastName:      $user->lastName(),
+            subscriptions: $subscriptions,
+        );
+    }
+}

--- a/app/Domain/Measurement/ValueObjects/AtmosphericPressure.php
+++ b/app/Domain/Measurement/ValueObjects/AtmosphericPressure.php
@@ -8,7 +8,11 @@ final class AtmosphericPressure
 {
     public function __construct(
         private readonly float $value,
-    ) {}
+    ) {
+        if ($value <= 0.0) {
+            throw new \InvalidArgumentException("Invalid atmospheric pressure: '{$value}'. Must be greater than 0.");
+        }
+    }
 
     public function value(): float
     {

--- a/app/Domain/User/Entities/User.php
+++ b/app/Domain/User/Entities/User.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Domain\User\Entities;
 
+use App\Domain\User\Exceptions\UserAlreadySubscribedException;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 
 final class User
 {
@@ -14,6 +16,7 @@ final class User
         private Email $email,
         private string $firstName,
         private string $lastName,
+        private array $subscriptions,
     ) {}
 
     public static function create(
@@ -21,8 +24,9 @@ final class User
         Email $email,
         string $firstName,
         string $lastName,
+        array $subscriptions = [],
     ): self {
-        return new self($id, $email, $firstName, $lastName);
+        return new self($id, $email, $firstName, $lastName, $subscriptions);
     }
 
     public function update(Email $email, string $firstName, string $lastName): void
@@ -30,6 +34,33 @@ final class User
         $this->email = $email;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
+    }
+
+    public function subscribe(StationId $stationId): void
+    {
+        if ($this->isSubscribedTo($stationId)) {
+            throw new UserAlreadySubscribedException($stationId->value());
+        }
+
+        $this->subscriptions[] = $stationId;
+    }
+
+    public function unsubscribe(StationId $stationId): void
+    {
+        $this->subscriptions = array_values(
+            array_filter(
+                $this->subscriptions,
+                fn (StationId $existing) => !$existing->equals($stationId),
+            )
+        );
+    }
+
+    public function isSubscribedTo(StationId $stationId): bool
+    {
+        return !empty(array_filter(
+            $this->subscriptions,
+            fn (StationId $existing) => $existing->equals($stationId),
+        ));
     }
 
     public function id(): UserId
@@ -50,5 +81,11 @@ final class User
     public function lastName(): string
     {
         return $this->lastName;
+    }
+
+    /** @return StationId[] */
+    public function subscriptions(): array
+    {
+        return $this->subscriptions;
     }
 }

--- a/app/Domain/User/Exceptions/UserAlreadySubscribedException.php
+++ b/app/Domain/User/Exceptions/UserAlreadySubscribedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exceptions;
+
+use RuntimeException;
+
+final class UserAlreadySubscribedException extends RuntimeException
+{
+    public function __construct(string $stationId)
+    {
+        parent::__construct("User is already subscribed to station: '{$stationId}'");
+    }
+}

--- a/app/Domain/WeatherStation/Repositories/WeatherStationRepository.php
+++ b/app/Domain/WeatherStation/Repositories/WeatherStationRepository.php
@@ -13,6 +13,9 @@ interface WeatherStationRepository
 
     public function findById(StationId $id): ?WeatherStation;
 
+    /** @param StationId[] $ids  @return WeatherStation[] */
+    public function findByIds(array $ids): array;
+
     public function findAll(): array;
 
     public function delete(StationId $id): void;

--- a/app/Infrastructure/Http/Controllers/UserController.php
+++ b/app/Infrastructure/Http/Controllers/UserController.php
@@ -12,22 +12,31 @@ use App\Application\User\GetAllUsers\GetAllUsersHandler;
 use App\Application\User\GetAllUsers\GetAllUsersQuery;
 use App\Application\User\GetUser\GetUserHandler;
 use App\Application\User\GetUser\GetUserQuery;
+use App\Application\User\SubscribeUserToStation\SubscribeUserToStationCommand;
+use App\Application\User\SubscribeUserToStation\SubscribeUserToStationHandler;
+use App\Application\User\UnsubscribeUserFromStation\UnsubscribeUserFromStationCommand;
+use App\Application\User\UnsubscribeUserFromStation\UnsubscribeUserFromStationHandler;
 use App\Application\User\UpdateUser\UpdateUserCommand;
 use App\Application\User\UpdateUser\UpdateUserHandler;
 use App\Domain\User\Exceptions\DuplicateEmailException;
+use App\Domain\User\Exceptions\UserAlreadySubscribedException;
 use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
 use App\Infrastructure\Http\Requests\CreateUserRequest;
+use App\Infrastructure\Http\Requests\SubscribeUserToStationRequest;
 use App\Infrastructure\Http\Requests\UpdateUserRequest;
 use Illuminate\Http\JsonResponse;
 
 final class UserController
 {
     public function __construct(
-        private readonly CreateUserHandler  $createHandler,
-        private readonly GetUserHandler     $getHandler,
-        private readonly GetAllUsersHandler $getAllHandler,
-        private readonly UpdateUserHandler  $updateHandler,
-        private readonly DeleteUserHandler  $deleteHandler,
+        private readonly CreateUserHandler               $createHandler,
+        private readonly GetUserHandler                  $getHandler,
+        private readonly GetAllUsersHandler              $getAllHandler,
+        private readonly UpdateUserHandler               $updateHandler,
+        private readonly DeleteUserHandler               $deleteHandler,
+        private readonly SubscribeUserToStationHandler   $subscribeHandler,
+        private readonly UnsubscribeUserFromStationHandler $unsubscribeHandler,
     ) {}
 
     public function index(): JsonResponse
@@ -85,6 +94,36 @@ final class UserController
     {
         try {
             $this->deleteHandler->handle(new DeleteUserCommand($id));
+
+            return response()->json(null, 204);
+        } catch (UserNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+
+    public function subscribe(SubscribeUserToStationRequest $request, string $userId): JsonResponse
+    {
+        try {
+            $user = $this->subscribeHandler->handle(new SubscribeUserToStationCommand(
+                userId:    $userId,
+                stationId: $request->input('station_id'),
+            ));
+
+            return response()->json($user);
+        } catch (UserNotFoundException|StationNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        } catch (UserAlreadySubscribedException $e) {
+            return response()->json(['message' => $e->getMessage()], 409);
+        }
+    }
+
+    public function unsubscribe(string $userId, string $stationId): JsonResponse
+    {
+        try {
+            $this->unsubscribeHandler->handle(new UnsubscribeUserFromStationCommand(
+                userId:    $userId,
+                stationId: $stationId,
+            ));
 
             return response()->json(null, 204);
         } catch (UserNotFoundException $e) {

--- a/app/Infrastructure/Http/Requests/CreateMeasurementRequest.php
+++ b/app/Infrastructure/Http/Requests/CreateMeasurementRequest.php
@@ -14,7 +14,7 @@ final class CreateMeasurementRequest extends FormRequest
             'station_id'           => ['required', 'string', 'uuid'],
             'temperature'          => ['required', 'numeric'],
             'humidity'             => ['required', 'numeric', 'between:0,100'],
-            'atmospheric_pressure' => ['required', 'numeric'],
+            'atmospheric_pressure' => ['required', 'numeric', 'gt:0'],
             'reported_at'          => ['required', 'date'],
         ];
     }

--- a/app/Infrastructure/Http/Requests/SubscribeUserToStationRequest.php
+++ b/app/Infrastructure/Http/Requests/SubscribeUserToStationRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class SubscribeUserToStationRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'station_id' => ['required', 'string', 'uuid'],
+        ];
+    }
+}

--- a/app/Infrastructure/Http/Requests/UpdateMeasurementRequest.php
+++ b/app/Infrastructure/Http/Requests/UpdateMeasurementRequest.php
@@ -13,7 +13,7 @@ final class UpdateMeasurementRequest extends FormRequest
         return [
             'temperature'          => ['required', 'numeric'],
             'humidity'             => ['required', 'numeric', 'between:0,100'],
-            'atmospheric_pressure' => ['required', 'numeric'],
+            'atmospheric_pressure' => ['required', 'numeric', 'gt:0'],
             'reported_at'          => ['required', 'date'],
         ];
     }

--- a/app/Infrastructure/Persistence/MongoDB/MongoUserRepository.php
+++ b/app/Infrastructure/Persistence/MongoDB/MongoUserRepository.php
@@ -8,6 +8,7 @@ use App\Domain\User\Entities\User;
 use App\Domain\User\Repositories\UserRepository;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 
 final class MongoUserRepository implements UserRepository
 {
@@ -16,9 +17,13 @@ final class MongoUserRepository implements UserRepository
         UserModel::updateOrCreate(
             ['_id' => $user->id()->value()],
             [
-                'email'      => $user->email()->value(),
-                'first_name' => $user->firstName(),
-                'last_name'  => $user->lastName(),
+                'email'         => $user->email()->value(),
+                'first_name'    => $user->firstName(),
+                'last_name'     => $user->lastName(),
+                'subscriptions' => array_map(
+                    fn (StationId $stationId) => $stationId->value(),
+                    $user->subscriptions(),
+                ),
             ]
         );
     }
@@ -51,11 +56,19 @@ final class MongoUserRepository implements UserRepository
 
     private function toDomain(UserModel $model): User
     {
+        $rawSubscriptions = is_array($model->subscriptions) ? $model->subscriptions : [];
+
+        $subscriptions = array_map(
+            fn (string $stationId) => StationId::fromString($stationId),
+            $rawSubscriptions,
+        );
+
         return User::create(
             UserId::fromString($model->_id),
             new Email($model->email),
             $model->first_name,
             $model->last_name,
+            $subscriptions,
         );
     }
 }

--- a/app/Infrastructure/Persistence/MongoDB/MongoWeatherStationRepository.php
+++ b/app/Infrastructure/Persistence/MongoDB/MongoWeatherStationRepository.php
@@ -37,6 +37,16 @@ final class MongoWeatherStationRepository implements WeatherStationRepository
         return $model ? $this->toDomain($model) : null;
     }
 
+    public function findByIds(array $ids): array
+    {
+        $stringIds = array_map(fn (StationId $stationId) => $stationId->value(), $ids);
+
+        return WeatherStationModel::whereIn('_id', $stringIds)
+            ->get()
+            ->map(fn (WeatherStationModel $model) => $this->toDomain($model))
+            ->all();
+    }
+
     public function findAll(): array
     {
         return WeatherStationModel::all()

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,5 +8,7 @@ use App\Infrastructure\Http\Controllers\WeatherStationController;
 use Illuminate\Support\Facades\Route;
 
 Route::apiResource('users', UserController::class);
+Route::post('users/{userId}/subscriptions', [UserController::class, 'subscribe']);
+Route::delete('users/{userId}/subscriptions/{stationId}', [UserController::class, 'unsubscribe']);
 Route::apiResource('stations', WeatherStationController::class);
 Route::apiResource('measurements', MeasurementController::class);

--- a/tests/Feature/Measurement/MeasurementApiTest.php
+++ b/tests/Feature/Measurement/MeasurementApiTest.php
@@ -69,6 +69,14 @@ test('returns 422 when required fields are missing', function () {
         ->assertJsonValidationErrors(['station_id', 'temperature', 'humidity', 'atmospheric_pressure', 'reported_at']);
 });
 
+test('returns 422 when atmospheric pressure is zero or negative', function () {
+    $stationId = createStation($this, createOwner($this));
+
+    $this->postJson('/api/measurements', measurementPayload($stationId, ['atmospheric_pressure' => 0.0]))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['atmospheric_pressure']);
+});
+
 test('returns 422 when humidity is out of range', function () {
     $stationId = createStation($this, createOwner($this));
 

--- a/tests/Feature/User/UserApiTest.php
+++ b/tests/Feature/User/UserApiTest.php
@@ -7,7 +7,7 @@ use Tests\Feature\RefreshMongoCollections;
 uses(RefreshMongoCollections::class);
 
 beforeEach(function () {
-    $this->collectionsToClean = ['users'];
+    $this->collectionsToClean = ['users', 'weather_stations'];
     $this->cleanCollections();
 });
 
@@ -156,4 +156,110 @@ test('deletes a user and returns 204', function () {
 test('returns 404 when deleting nonexistent user', function () {
     $this->deleteJson('/api/users/00000000-0000-4000-a000-000000000000')
         ->assertStatus(404);
+});
+
+// -------------------------------------------------------------------------
+// POST /api/users/{id}/subscriptions
+// -------------------------------------------------------------------------
+
+test('subscribes a user to a station and returns station details', function () {
+    $user = $this->postJson('/api/users', [
+        'email'      => 'john@example.com',
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ])->json();
+
+    $station = $this->postJson('/api/stations', [
+        'owner_id'     => $user['id'],
+        'station_name' => 'Station Alpha',
+        'latitude'     => -34.6,
+        'longitude'    => -58.3,
+        'sensor_model' => 'Davis',
+    ])->json();
+
+    $this->postJson("/api/users/{$user['id']}/subscriptions", [
+        'station_id' => $station['id'],
+    ])->assertStatus(200)
+        ->assertJsonStructure(['id', 'email', 'firstName', 'lastName', 'subscriptions'])
+        ->assertJsonFragment([
+            'stationId' => $station['id'],
+            'name'      => 'Station Alpha',
+        ]);
+});
+
+test('returns 409 when subscribing to a station already subscribed', function () {
+    $user = $this->postJson('/api/users', [
+        'email'      => 'john@example.com',
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ])->json();
+
+    $station = $this->postJson('/api/stations', [
+        'owner_id'     => $user['id'],
+        'station_name' => 'Station Alpha',
+        'latitude'     => -34.6,
+        'longitude'    => -58.3,
+        'sensor_model' => 'Davis',
+    ])->json();
+
+    $this->postJson("/api/users/{$user['id']}/subscriptions", ['station_id' => $station['id']]);
+    $this->postJson("/api/users/{$user['id']}/subscriptions", ['station_id' => $station['id']])
+        ->assertStatus(409);
+});
+
+test('returns 404 when subscribing to a nonexistent station', function () {
+    $user = $this->postJson('/api/users', [
+        'email'      => 'john@example.com',
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ])->json();
+
+    $this->postJson("/api/users/{$user['id']}/subscriptions", [
+        'station_id' => '00000000-0000-4000-a000-000000000000',
+    ])->assertStatus(404);
+});
+
+test('returns 404 when subscribing a nonexistent user', function () {
+    $this->postJson('/api/users/00000000-0000-4000-a000-000000000000/subscriptions', [
+        'station_id' => '00000000-0000-4000-a000-000000000001',
+    ])->assertStatus(404);
+});
+
+// -------------------------------------------------------------------------
+// DELETE /api/users/{id}/subscriptions/{stationId}
+// -------------------------------------------------------------------------
+
+test('unsubscribes a user from a station', function () {
+    $user = $this->postJson('/api/users', [
+        'email'      => 'john@example.com',
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ])->json();
+
+    $station = $this->postJson('/api/stations', [
+        'owner_id'     => $user['id'],
+        'station_name' => 'Station Alpha',
+        'latitude'     => -34.6,
+        'longitude'    => -58.3,
+        'sensor_model' => 'Davis',
+    ])->json();
+
+    $this->postJson("/api/users/{$user['id']}/subscriptions", ['station_id' => $station['id']]);
+
+    $this->deleteJson("/api/users/{$user['id']}/subscriptions/{$station['id']}")
+        ->assertStatus(204);
+
+    $this->getJson("/api/users/{$user['id']}")
+        ->assertJsonFragment(['subscriptions' => []]);
+});
+
+test('unsubscribe returns 204 even when not subscribed', function () {
+    $user = $this->postJson('/api/users', [
+        'email'      => 'john@example.com',
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ])->json();
+
+    $this->deleteJson("/api/users/{$user['id']}/subscriptions/00000000-0000-4000-a000-000000000000")
+        ->assertStatus(204);
 });

--- a/tests/Unit/Application/User/GetAllUsersHandlerTest.php
+++ b/tests/Unit/Application/User/GetAllUsersHandlerTest.php
@@ -4,30 +4,34 @@ declare(strict_types=1);
 
 use App\Application\User\GetAllUsers\GetAllUsersHandler;
 use App\Application\User\GetAllUsers\GetAllUsersQuery;
-use App\Application\User\UserResponse;
+use App\Application\User\UserResponseWithSubscriptions;
 use App\Domain\User\Entities\User;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
 use Tests\Unit\Domain\User\FakeUserRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
 
 test('returns empty array when no users exist', function () {
-    $repo = new FakeUserRepository();
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
 
-    $result = (new GetAllUsersHandler($repo))->handle(new GetAllUsersQuery());
+    $result = (new GetAllUsersHandler($userRepo, $stationRepo))->handle(new GetAllUsersQuery());
 
     expect($result)->toBeEmpty();
 });
 
 test('returns all users as responses', function () {
-    $repo = new FakeUserRepository();
-    $repo->seed(
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
+
+    $userRepo->seed(
         User::create(UserId::generate(), new Email('john@example.com'), 'John', 'Doe'),
         User::create(UserId::generate(), new Email('jane@example.com'), 'Jane', 'Smith'),
     );
 
-    $result = (new GetAllUsersHandler($repo))->handle(new GetAllUsersQuery());
+    $result = (new GetAllUsersHandler($userRepo, $stationRepo))->handle(new GetAllUsersQuery());
 
     expect($result)->toHaveCount(2)
-        ->and($result[0])->toBeInstanceOf(UserResponse::class)
-        ->and($result[1])->toBeInstanceOf(UserResponse::class);
+        ->and($result[0])->toBeInstanceOf(UserResponseWithSubscriptions::class)
+        ->and($result[1])->toBeInstanceOf(UserResponseWithSubscriptions::class);
 });

--- a/tests/Unit/Application/User/GetUserHandlerTest.php
+++ b/tests/Unit/Application/User/GetUserHandlerTest.php
@@ -4,29 +4,34 @@ declare(strict_types=1);
 
 use App\Application\User\GetUser\GetUserHandler;
 use App\Application\User\GetUser\GetUserQuery;
-use App\Application\User\UserResponse;
+use App\Application\User\UserResponseWithSubscriptions;
 use App\Domain\User\Entities\User;
 use App\Domain\User\Exceptions\UserNotFoundException;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
 use Tests\Unit\Domain\User\FakeUserRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
 
 test('returns a user response when user exists', function () {
-    $id = UserId::generate();
-    $repo = new FakeUserRepository();
-    $repo->seed(User::create($id, new Email('john@example.com'), 'John', 'Doe'));
+    $id          = UserId::generate();
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
 
-    $response = (new GetUserHandler($repo))->handle(new GetUserQuery($id->value()));
+    $userRepo->seed(User::create($id, new Email('john@example.com'), 'John', 'Doe'));
 
-    expect($response)->toBeInstanceOf(UserResponse::class)
+    $response = (new GetUserHandler($userRepo, $stationRepo))->handle(new GetUserQuery($id->value()));
+
+    expect($response)->toBeInstanceOf(UserResponseWithSubscriptions::class)
         ->and($response->id)->toBe($id->value())
         ->and($response->email)->toBe('john@example.com')
         ->and($response->firstName)->toBe('John')
-        ->and($response->lastName)->toBe('Doe');
+        ->and($response->lastName)->toBe('Doe')
+        ->and($response->subscriptions)->toBe([]);
 });
 
 test('throws when user does not exist', function () {
-    $repo = new FakeUserRepository();
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
 
-    (new GetUserHandler($repo))->handle(new GetUserQuery(UserId::generate()->value()));
+    (new GetUserHandler($userRepo, $stationRepo))->handle(new GetUserQuery(UserId::generate()->value()));
 })->throws(UserNotFoundException::class);

--- a/tests/Unit/Application/User/SubscribeUserToStationHandlerTest.php
+++ b/tests/Unit/Application/User/SubscribeUserToStationHandlerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\User\SubscribeUserToStation\SubscribeUserToStationCommand;
+use App\Application\User\SubscribeUserToStation\SubscribeUserToStationHandler;
+use App\Application\User\SubscriptionResponse;
+use App\Application\User\UserResponseWithSubscriptions;
+use App\Domain\User\Entities\User;
+use App\Domain\User\Exceptions\UserAlreadySubscribedException;
+use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\User\ValueObjects\Email;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Enums\StationStatus;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\User\FakeUserRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+test('subscribes user to a station and returns updated response with station details', function () {
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
+
+    $userId    = UserId::generate();
+    $stationId = StationId::generate();
+
+    $userRepo->seed(User::create($userId, new Email('john@example.com'), 'John', 'Doe'));
+    $stationRepo->seed(WeatherStation::create($stationId, UserId::generate(), 'Station Alpha', new Location(0.0, 0.0), 'SensorX', StationStatus::Active));
+
+    $response = (new SubscribeUserToStationHandler($userRepo, $stationRepo))
+        ->handle(new SubscribeUserToStationCommand($userId->value(), $stationId->value()));
+
+    expect($response)->toBeInstanceOf(UserResponseWithSubscriptions::class)
+        ->and($response->subscriptions)->toHaveCount(1)
+        ->and($response->subscriptions[0])->toBeInstanceOf(SubscriptionResponse::class)
+        ->and($response->subscriptions[0]->stationId)->toBe($stationId->value())
+        ->and($response->subscriptions[0]->name)->toBe('Station Alpha');
+});
+
+test('throws when user does not exist', function () {
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationId   = StationId::generate();
+
+    $stationRepo->seed(WeatherStation::create($stationId, UserId::generate(), 'Station Alpha', new Location(0.0, 0.0), 'SensorX', StationStatus::Active));
+
+    (new SubscribeUserToStationHandler($userRepo, $stationRepo))
+        ->handle(new SubscribeUserToStationCommand(UserId::generate()->value(), $stationId->value()));
+})->throws(UserNotFoundException::class);
+
+test('throws when station does not exist', function () {
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
+
+    $userId = UserId::generate();
+    $userRepo->seed(User::create($userId, new Email('john@example.com'), 'John', 'Doe'));
+
+    (new SubscribeUserToStationHandler($userRepo, $stationRepo))
+        ->handle(new SubscribeUserToStationCommand($userId->value(), StationId::generate()->value()));
+})->throws(StationNotFoundException::class);
+
+test('throws when user is already subscribed to the station', function () {
+    $userRepo    = new FakeUserRepository();
+    $stationRepo = new FakeWeatherStationRepository();
+
+    $userId    = UserId::generate();
+    $stationId = StationId::generate();
+
+    $userRepo->seed(User::create($userId, new Email('john@example.com'), 'John', 'Doe', [$stationId]));
+    $stationRepo->seed(WeatherStation::create($stationId, UserId::generate(), 'Station Alpha', new Location(0.0, 0.0), 'SensorX', StationStatus::Active));
+
+    (new SubscribeUserToStationHandler($userRepo, $stationRepo))
+        ->handle(new SubscribeUserToStationCommand($userId->value(), $stationId->value()));
+})->throws(UserAlreadySubscribedException::class);

--- a/tests/Unit/Application/User/UnsubscribeUserFromStationHandlerTest.php
+++ b/tests/Unit/Application/User/UnsubscribeUserFromStationHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\User\UnsubscribeUserFromStation\UnsubscribeUserFromStationCommand;
+use App\Application\User\UnsubscribeUserFromStation\UnsubscribeUserFromStationHandler;
+use App\Domain\User\Entities\User;
+use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\User\ValueObjects\Email;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\User\FakeUserRepository;
+
+test('unsubscribes user from a station', function () {
+    $userRepo  = new FakeUserRepository();
+    $stationId = StationId::generate();
+    $userId    = UserId::generate();
+
+    $userRepo->seed(User::create($userId, new Email('john@example.com'), 'John', 'Doe', [$stationId]));
+
+    (new UnsubscribeUserFromStationHandler($userRepo))
+        ->handle(new UnsubscribeUserFromStationCommand($userId->value(), $stationId->value()));
+
+    $saved = $userRepo->findById($userId);
+    expect($saved->isSubscribedTo($stationId))->toBeFalse();
+});
+
+test('is silent when user was not subscribed to the station', function () {
+    $userRepo = new FakeUserRepository();
+    $userId   = UserId::generate();
+
+    $userRepo->seed(User::create($userId, new Email('john@example.com'), 'John', 'Doe'));
+
+    (new UnsubscribeUserFromStationHandler($userRepo))
+        ->handle(new UnsubscribeUserFromStationCommand($userId->value(), StationId::generate()->value()));
+
+    $saved = $userRepo->findById($userId);
+    expect($saved->subscriptions())->toBe([]);
+});
+
+test('throws when user does not exist', function () {
+    $userRepo = new FakeUserRepository();
+
+    (new UnsubscribeUserFromStationHandler($userRepo))
+        ->handle(new UnsubscribeUserFromStationCommand(UserId::generate()->value(), StationId::generate()->value()));
+})->throws(UserNotFoundException::class);

--- a/tests/Unit/Domain/Measurement/Entities/MeasurementTest.php
+++ b/tests/Unit/Domain/Measurement/Entities/MeasurementTest.php
@@ -59,6 +59,14 @@ test('updates measurement and recalculates alerts', function () {
         ->and($measurement->alertTypes())->toContain(AlertType::ExtremeHeat);
 });
 
+test('throws when atmospheric pressure is zero', function () {
+    new AtmosphericPressure(0.0);
+})->throws(InvalidArgumentException::class);
+
+test('throws when atmospheric pressure is negative', function () {
+    new AtmosphericPressure(-10.0);
+})->throws(InvalidArgumentException::class);
+
 test('alert clears after update to normal readings', function () {
     $measurement = makeMeasurement(temp: 41.0);
 

--- a/tests/Unit/Domain/User/Entities/UserTest.php
+++ b/tests/Unit/Domain/User/Entities/UserTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use App\Domain\User\Entities\User;
+use App\Domain\User\Exceptions\UserAlreadySubscribedException;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 
 test('creates a user with correct data', function () {
     $user = User::create(
@@ -17,7 +19,8 @@ test('creates a user with correct data', function () {
     expect($user->email()->value())->toBe('john@example.com')
         ->and($user->firstName())->toBe('John')
         ->and($user->lastName())->toBe('Doe')
-        ->and($user->id())->toBeInstanceOf(UserId::class);
+        ->and($user->id())->toBeInstanceOf(UserId::class)
+        ->and($user->subscriptions())->toBe([]);
 });
 
 test('updates user data', function () {
@@ -42,4 +45,40 @@ test('id does not change after update', function () {
     $user->update(new Email('jane@example.com'), 'Jane', 'Smith');
 
     expect($user->id()->equals($id))->toBeTrue();
+});
+
+test('subscribes user to a station', function () {
+    $user      = User::create(UserId::generate(), new Email('john@example.com'), 'John', 'Doe');
+    $stationId = StationId::generate();
+
+    $user->subscribe($stationId);
+
+    expect($user->subscriptions())->toHaveCount(1)
+        ->and($user->isSubscribedTo($stationId))->toBeTrue();
+});
+
+test('throws when subscribing to the same station twice', function () {
+    $user      = User::create(UserId::generate(), new Email('john@example.com'), 'John', 'Doe');
+    $stationId = StationId::generate();
+
+    $user->subscribe($stationId);
+    $user->subscribe($stationId);
+})->throws(UserAlreadySubscribedException::class);
+
+test('unsubscribes user from a station', function () {
+    $stationId = StationId::generate();
+    $user      = User::create(UserId::generate(), new Email('john@example.com'), 'John', 'Doe', [$stationId]);
+
+    $user->unsubscribe($stationId);
+
+    expect($user->subscriptions())->toBe([])
+        ->and($user->isSubscribedTo($stationId))->toBeFalse();
+});
+
+test('unsubscribe is silent when station was not subscribed', function () {
+    $user = User::create(UserId::generate(), new Email('john@example.com'), 'John', 'Doe');
+
+    $user->unsubscribe(StationId::generate());
+
+    expect($user->subscriptions())->toBe([]);
 });

--- a/tests/Unit/Domain/WeatherStation/FakeWeatherStationRepository.php
+++ b/tests/Unit/Domain/WeatherStation/FakeWeatherStationRepository.php
@@ -23,6 +23,13 @@ final class FakeWeatherStationRepository implements WeatherStationRepository
         return $this->stations[$id->value()] ?? null;
     }
 
+    public function findByIds(array $ids): array
+    {
+        return array_values(array_filter(
+            array_map(fn (StationId $stationId) => $this->stations[$stationId->value()] ?? null, $ids),
+        ));
+    }
+
     public function findAll(): array
     {
         return array_values($this->stations);


### PR DESCRIPTION
  - Los usuarios ahora pueden suscribirse y desuscribirse de estaciones meteorológicas.

  - Las suscripciones se almacenan como una lista de StationIds dentro del aggregate User y se persisten en MongoDB. Todos los endpoints de lectura de usuarios ahora incluyen la lista completa de suscripciones con los detalles de cada estación.

  - Suscribirse valida que tanto el usuario como la estación existan, y previene duplicados

  - Desuscribirse es idempotente.

  - GetUser, GetAllUsers y sus handlers fueron actualizados para devolver UserResponseWithSubscriptions en lugar del UserResponse plano anterior.