### PR TITLE
bug: delete de usuario y estación no valida registros dependientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,17 @@ Esto levanta dos contenedores: la aplicación Laravel (puerto 80) y MongoDB (pue
 ./vendor/bin/sail artisan key:generate
 ```
 
+> **Error de permisos:** Si aparece _Permission denied_ sobre `storage/logs/laravel.log` o `.env`, corré esto primero y luego repetí el comando:
+> ```bash
+> docker exec -u root weatherflow-app chmod -R 777 /var/www/html/storage /var/www/html/bootstrap/cache
+> docker exec -u root weatherflow-app chmod 666 /var/www/html/.env
+> ```
+
 ### 7. Verificar que todo funciona
 
 ```bash
 ./vendor/bin/sail artisan about
 ```
-
-La API ya está disponible en **http://localhost**.
 
 ---
 

--- a/app/Application/User/DeleteUser/DeleteUserHandler.php
+++ b/app/Application/User/DeleteUser/DeleteUserHandler.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Application\User\DeleteUser;
 
+use App\Domain\User\Exceptions\UserHasStationsException;
 use App\Domain\User\Exceptions\UserNotFoundException;
 use App\Domain\User\Repositories\UserRepository;
 use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
 
 final class DeleteUserHandler
 {
     public function __construct(
-        private readonly UserRepository $userRepository,
+        private readonly UserRepository           $userRepository,
+        private readonly WeatherStationRepository $stationRepository,
     ) {}
 
     public function handle(DeleteUserCommand $command): void
@@ -20,6 +23,10 @@ final class DeleteUserHandler
 
         if ($this->userRepository->findById($userId) === null) {
             throw new UserNotFoundException($command->id);
+        }
+
+        if ($this->stationRepository->hasStationsOwnedBy($userId)) {
+            throw new UserHasStationsException($command->id);
         }
 
         $this->userRepository->delete($userId);

--- a/app/Application/WeatherStation/DeleteStation/DeleteStationHandler.php
+++ b/app/Application/WeatherStation/DeleteStation/DeleteStationHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Application\WeatherStation\DeleteStation;
 
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\WeatherStation\Exceptions\StationHasMeasurementsException;
 use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
 use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
 use App\Domain\WeatherStation\ValueObjects\StationId;
@@ -12,6 +14,7 @@ final class DeleteStationHandler
 {
     public function __construct(
         private readonly WeatherStationRepository $stationRepository,
+        private readonly MeasurementRepository    $measurementRepository,
     ) {}
 
     public function handle(DeleteStationCommand $command): void
@@ -20,6 +23,10 @@ final class DeleteStationHandler
 
         if ($this->stationRepository->findById($stationId) === null) {
             throw new StationNotFoundException($command->id);
+        }
+
+        if ($this->measurementRepository->hasMeasurementsForStation($stationId)) {
+            throw new StationHasMeasurementsException($command->id);
         }
 
         $this->stationRepository->delete($stationId);

--- a/app/Domain/Measurement/Repositories/MeasurementRepository.php
+++ b/app/Domain/Measurement/Repositories/MeasurementRepository.php
@@ -7,6 +7,7 @@ namespace App\Domain\Measurement\Repositories;
 use App\Domain\Measurement\Entities\Measurement;
 use App\Domain\Measurement\ValueObjects\MeasurementFilters;
 use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 
 interface MeasurementRepository
 {
@@ -15,6 +16,8 @@ interface MeasurementRepository
     public function findById(MeasurementId $id): ?Measurement;
 
     public function findAll(MeasurementFilters $filters = new MeasurementFilters()): array;
+
+    public function hasMeasurementsForStation(StationId $stationId): bool;
 
     public function delete(MeasurementId $id): void;
 }

--- a/app/Domain/User/Exceptions/UserHasStationsException.php
+++ b/app/Domain/User/Exceptions/UserHasStationsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exceptions;
+
+use RuntimeException;
+
+final class UserHasStationsException extends RuntimeException
+{
+    public function __construct(string $userId)
+    {
+        parent::__construct("User {$userId} owns one or more weather stations and cannot be deleted.");
+    }
+}

--- a/app/Domain/WeatherStation/Exceptions/StationHasMeasurementsException.php
+++ b/app/Domain/WeatherStation/Exceptions/StationHasMeasurementsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\WeatherStation\Exceptions;
+
+use RuntimeException;
+
+final class StationHasMeasurementsException extends RuntimeException
+{
+    public function __construct(string $stationId)
+    {
+        parent::__construct("Station {$stationId} has measurements and cannot be deleted.");
+    }
+}

--- a/app/Domain/WeatherStation/Repositories/WeatherStationRepository.php
+++ b/app/Domain/WeatherStation/Repositories/WeatherStationRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\WeatherStation\Repositories;
 
+use App\Domain\User\ValueObjects\UserId;
 use App\Domain\WeatherStation\Entities\WeatherStation;
 use App\Domain\WeatherStation\ValueObjects\StationId;
 
@@ -15,6 +16,8 @@ interface WeatherStationRepository
 
     /** @param StationId[] $ids  @return WeatherStation[] */
     public function findByIds(array $ids): array;
+
+    public function hasStationsOwnedBy(UserId $ownerId): bool;
 
     public function findAll(): array;
 

--- a/app/Infrastructure/Http/Controllers/UserController.php
+++ b/app/Infrastructure/Http/Controllers/UserController.php
@@ -20,6 +20,7 @@ use App\Application\User\UpdateUser\UpdateUserCommand;
 use App\Application\User\UpdateUser\UpdateUserHandler;
 use App\Domain\User\Exceptions\DuplicateEmailException;
 use App\Domain\User\Exceptions\UserAlreadySubscribedException;
+use App\Domain\User\Exceptions\UserHasStationsException;
 use App\Domain\User\Exceptions\UserNotFoundException;
 use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
 use App\Infrastructure\Http\Requests\CreateUserRequest;
@@ -98,6 +99,8 @@ final class UserController
             return response()->json(null, 204);
         } catch (UserNotFoundException $e) {
             return response()->json(['message' => $e->getMessage()], 404);
+        } catch (UserHasStationsException $e) {
+            return response()->json(['message' => $e->getMessage()], 409);
         }
     }
 

--- a/app/Infrastructure/Http/Controllers/WeatherStationController.php
+++ b/app/Infrastructure/Http/Controllers/WeatherStationController.php
@@ -15,6 +15,7 @@ use App\Application\WeatherStation\GetStation\GetStationQuery;
 use App\Application\WeatherStation\UpdateStation\UpdateStationCommand;
 use App\Application\WeatherStation\UpdateStation\UpdateStationHandler;
 use App\Domain\User\Exceptions\UserNotFoundException;
+use App\Domain\WeatherStation\Exceptions\StationHasMeasurementsException;
 use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
 use App\Infrastructure\Http\Requests\CreateStationRequest;
 use App\Infrastructure\Http\Requests\UpdateStationRequest;
@@ -91,6 +92,8 @@ final class WeatherStationController
             return response()->json(null, 204);
         } catch (StationNotFoundException $e) {
             return response()->json(['message' => $e->getMessage()], 404);
+        } catch (StationHasMeasurementsException $e) {
+            return response()->json(['message' => $e->getMessage()], 409);
         }
     }
 }

--- a/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
+++ b/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
@@ -54,6 +54,11 @@ final class MongoMeasurementRepository implements MeasurementRepository
             ->all();
     }
 
+    public function hasMeasurementsForStation(StationId $stationId): bool
+    {
+        return MeasurementModel::where('station_id', $stationId->value())->exists();
+    }
+
     public function delete(MeasurementId $id): void
     {
         MeasurementModel::destroy($id->value());

--- a/app/Infrastructure/Persistence/MongoDB/MongoWeatherStationRepository.php
+++ b/app/Infrastructure/Persistence/MongoDB/MongoWeatherStationRepository.php
@@ -47,6 +47,11 @@ final class MongoWeatherStationRepository implements WeatherStationRepository
             ->all();
     }
 
+    public function hasStationsOwnedBy(UserId $ownerId): bool
+    {
+        return WeatherStationModel::where('owner_id', $ownerId->value())->exists();
+    }
+
     public function findAll(): array
     {
         return WeatherStationModel::all()

--- a/docs/diagrama-clases.puml
+++ b/docs/diagrama-clases.puml
@@ -167,6 +167,7 @@ package "Puertos (Interfaces)" <<puertos>> {
         +save(WeatherStation) : void
         +findById(StationId) : WeatherStation?
         +findByIds(StationId[]) : WeatherStation[]
+        +hasStationsOwnedBy(UserId) : bool
         +findAll() : WeatherStation[]
         +delete(StationId) : void
     }
@@ -175,6 +176,7 @@ package "Puertos (Interfaces)" <<puertos>> {
         +save(Measurement) : void
         +findById(MeasurementId) : Measurement?
         +findAll(filters) : Measurement[]
+        +hasMeasurementsForStation(StationId) : bool
         +delete(MeasurementId) : void
     }
 }
@@ -257,6 +259,7 @@ SubscribeUserToStationHandler  --|> AbstractUserHandler
 CreateUserHandler              --> UserRepository
 UpdateUserHandler              --> UserRepository
 DeleteUserHandler              --> UserRepository
+DeleteUserHandler              --> WeatherStationRepository
 UnsubscribeUserFromStationHandler --> UserRepository
 
 CreateStationHandler           --> WeatherStationRepository
@@ -264,6 +267,7 @@ GetStationHandler              --> WeatherStationRepository
 GetAllStationsHandler          --> WeatherStationRepository
 UpdateStationHandler           --> WeatherStationRepository
 DeleteStationHandler           --> WeatherStationRepository
+DeleteStationHandler           --> MeasurementRepository
 
 CreateMeasurementHandler       --> MeasurementRepository
 CreateMeasurementHandler       --> WeatherStationRepository

--- a/public/docs/openapi.yaml
+++ b/public/docs/openapi.yaml
@@ -145,6 +145,17 @@ paths:
           description: Usuario eliminado correctamente
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: El usuario tiene estaciones meteorológicas a su cargo y no puede eliminarse
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "User 550e8400-e29b-41d4-a716-446655440000 owns one or more weather stations and cannot be deleted."
 
   /users/{userId}/subscriptions:
     parameters:
@@ -333,6 +344,17 @@ paths:
           description: Estación eliminada correctamente
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: La estación tiene mediciones asociadas y no puede eliminarse
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Station 660e8400-e29b-41d4-a716-446655440001 has measurements and cannot be deleted."
 
   # ---------------------------------------------------------------------------
   # MEASUREMENTS
@@ -434,7 +456,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorMessage'
+                type: object
+                properties:
+                  message:
+                    type: string
+              example:
+                message: "Weather station not found: '660e8400-e29b-41d4-a716-446655440001'"
 
   /measurements/{id}:
     parameters:

--- a/tests/Feature/User/UserApiTest.php
+++ b/tests/Feature/User/UserApiTest.php
@@ -158,6 +158,24 @@ test('returns 404 when deleting nonexistent user', function () {
         ->assertStatus(404);
 });
 
+test('returns 409 when deleting a user who owns stations', function () {
+    $user = $this->postJson('/api/users', [
+        'email'      => 'john@example.com',
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ])->json();
+
+    $this->postJson('/api/stations', [
+        'owner_id'     => $user['id'],
+        'station_name' => 'Station Alpha',
+        'latitude'     => -34.6,
+        'longitude'    => -58.3,
+        'sensor_model' => 'Davis',
+    ]);
+
+    $this->deleteJson("/api/users/{$user['id']}")->assertStatus(409);
+});
+
 // -------------------------------------------------------------------------
 // POST /api/users/{id}/subscriptions
 // -------------------------------------------------------------------------

--- a/tests/Feature/WeatherStation/WeatherStationApiTest.php
+++ b/tests/Feature/WeatherStation/WeatherStationApiTest.php
@@ -7,7 +7,7 @@ use Tests\Feature\RefreshMongoCollections;
 uses(RefreshMongoCollections::class);
 
 beforeEach(function () {
-    $this->collectionsToClean = ['weather_stations', 'users'];
+    $this->collectionsToClean = ['weather_stations', 'users', 'measurements'];
     $this->cleanCollections();
 });
 
@@ -200,4 +200,26 @@ test('deletes a station and returns 204', function () {
 test('returns 404 when deleting nonexistent station', function () {
     $this->deleteJson('/api/stations/00000000-0000-4000-a000-000000000000')
         ->assertStatus(404);
+});
+
+test('returns 409 when deleting a station that has measurements', function () {
+    $ownerId = createUser($this);
+
+    $station = $this->postJson('/api/stations', [
+        'owner_id'     => $ownerId,
+        'station_name' => 'Estación Central',
+        'latitude'     => -34.6037,
+        'longitude'    => -58.3816,
+        'sensor_model' => 'Davis Vantage Pro2',
+    ])->json();
+
+    $this->postJson('/api/measurements', [
+        'station_id'           => $station['id'],
+        'temperature'          => 25.0,
+        'humidity'             => 60.0,
+        'atmospheric_pressure' => 1013.0,
+        'reported_at'          => '2024-01-01T00:00:00Z',
+    ]);
+
+    $this->deleteJson("/api/stations/{$station['id']}")->assertStatus(409);
 });

--- a/tests/Unit/Application/User/DeleteUserHandlerTest.php
+++ b/tests/Unit/Application/User/DeleteUserHandlerTest.php
@@ -5,23 +5,46 @@ declare(strict_types=1);
 use App\Application\User\DeleteUser\DeleteUserCommand;
 use App\Application\User\DeleteUser\DeleteUserHandler;
 use App\Domain\User\Entities\User;
+use App\Domain\User\Exceptions\UserHasStationsException;
 use App\Domain\User\Exceptions\UserNotFoundException;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 use Tests\Unit\Domain\User\FakeUserRepository;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
 
 test('deletes an existing user', function () {
     $id = UserId::generate();
-    $repo = new FakeUserRepository();
-    $repo->seed(User::create($id, new Email('john@example.com'), 'John', 'Doe'));
+    $userRepo = new FakeUserRepository();
+    $userRepo->seed(User::create($id, new Email('john@example.com'), 'John', 'Doe'));
 
-    (new DeleteUserHandler($repo))->handle(new DeleteUserCommand($id->value()));
+    (new DeleteUserHandler($userRepo, new FakeWeatherStationRepository()))
+        ->handle(new DeleteUserCommand($id->value()));
 
-    expect($repo->findById($id))->toBeNull();
+    expect($userRepo->findById($id))->toBeNull();
 });
 
 test('throws when user does not exist', function () {
-    $repo = new FakeUserRepository();
-
-    (new DeleteUserHandler($repo))->handle(new DeleteUserCommand(UserId::generate()->value()));
+    (new DeleteUserHandler(new FakeUserRepository(), new FakeWeatherStationRepository()))
+        ->handle(new DeleteUserCommand(UserId::generate()->value()));
 })->throws(UserNotFoundException::class);
+
+test('throws when user owns stations', function () {
+    $userId = UserId::generate();
+    $userRepo = new FakeUserRepository();
+    $userRepo->seed(User::create($userId, new Email('john@example.com'), 'John', 'Doe'));
+
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed(WeatherStation::create(
+        StationId::generate(),
+        $userId,
+        'Station Alpha',
+        new Location(0.0, 0.0),
+        'Sensor X',
+    ));
+
+    (new DeleteUserHandler($userRepo, $stationRepo))
+        ->handle(new DeleteUserCommand($userId->value()));
+})->throws(UserHasStationsException::class);

--- a/tests/Unit/Application/WeatherStation/DeleteStationHandlerTest.php
+++ b/tests/Unit/Application/WeatherStation/DeleteStationHandlerTest.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 use App\Application\WeatherStation\DeleteStation\DeleteStationCommand;
 use App\Application\WeatherStation\DeleteStation\DeleteStationHandler;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
 use App\Domain\User\ValueObjects\UserId;
 use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Exceptions\StationHasMeasurementsException;
 use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
 use App\Domain\WeatherStation\ValueObjects\Location;
 use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
 use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
 
 test('deletes an existing station', function () {
@@ -22,12 +29,38 @@ test('deletes an existing station', function () {
     );
     $repo->seed($station);
 
-    (new DeleteStationHandler($repo))->handle(new DeleteStationCommand($station->id()->value()));
+    (new DeleteStationHandler($repo, new FakeMeasurementRepository()))
+        ->handle(new DeleteStationCommand($station->id()->value()));
 
     expect($repo->findById($station->id()))->toBeNull();
 });
 
 test('throws when station does not exist', function () {
-    (new DeleteStationHandler(new FakeWeatherStationRepository()))
+    (new DeleteStationHandler(new FakeWeatherStationRepository(), new FakeMeasurementRepository()))
         ->handle(new DeleteStationCommand('00000000-0000-4000-a000-000000000000'));
 })->throws(StationNotFoundException::class);
+
+test('throws when station has measurements', function () {
+    $stationRepo = new FakeWeatherStationRepository();
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(0.0, 0.0),
+        'Sensor X',
+    );
+    $stationRepo->seed($station);
+
+    $measurementRepo = new FakeMeasurementRepository();
+    $measurementRepo->seed(Measurement::create(
+        MeasurementId::generate(),
+        $station->id(),
+        new Temperature(25.0),
+        new Humidity(60.0),
+        new AtmosphericPressure(1013.0),
+        new DateTimeImmutable(),
+    ));
+
+    (new DeleteStationHandler($stationRepo, $measurementRepo))
+        ->handle(new DeleteStationCommand($station->id()->value()));
+})->throws(StationHasMeasurementsException::class);

--- a/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
+++ b/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
@@ -8,6 +8,7 @@ use App\Domain\Measurement\Entities\Measurement;
 use App\Domain\Measurement\Repositories\MeasurementRepository;
 use App\Domain\Measurement\ValueObjects\MeasurementFilters;
 use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 
 final class FakeMeasurementRepository implements MeasurementRepository
 {
@@ -29,6 +30,14 @@ final class FakeMeasurementRepository implements MeasurementRepository
         return array_values(array_filter(
             $this->measurements,
             fn(Measurement $measurement) => $this->matchesFilters($measurement, $filters),
+        ));
+    }
+
+    public function hasMeasurementsForStation(StationId $stationId): bool
+    {
+        return !empty(array_filter(
+            $this->measurements,
+            fn (Measurement $measurement) => $measurement->stationId()->value() === $stationId->value(),
         ));
     }
 

--- a/tests/Unit/Domain/WeatherStation/FakeWeatherStationRepository.php
+++ b/tests/Unit/Domain/WeatherStation/FakeWeatherStationRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Domain\WeatherStation;
 
+use App\Domain\User\ValueObjects\UserId;
 use App\Domain\WeatherStation\Entities\WeatherStation;
 use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
 use App\Domain\WeatherStation\ValueObjects\StationId;
@@ -27,6 +28,14 @@ final class FakeWeatherStationRepository implements WeatherStationRepository
     {
         return array_values(array_filter(
             array_map(fn (StationId $stationId) => $this->stations[$stationId->value()] ?? null, $ids),
+        ));
+    }
+
+    public function hasStationsOwnedBy(UserId $ownerId): bool
+    {
+        return !empty(array_filter(
+            $this->stations,
+            fn (WeatherStation $station) => $station->ownerId()->value() === $ownerId->value(),
         ));
     }
 


### PR DESCRIPTION
-  Se restringen los deletes de usuario y estación para evitar referencias huérfanas en la base de datos. Ahora, si un    usuario tiene estaciones a su cargo o una estación tiene     mediciones registradas, el sistema rechaza el borrado con un 409 en lugar de dejar datos inconsistentes. El cliente debe eliminar los dependientes primero.
- Se actualizo el readme