### PR TITLE
feat: consumer de StationRenamed para sincronizar station_name en med…

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -83,6 +83,26 @@ services:
     networks:
       - weatherflow
 
+  monitor-worker:
+    container_name: weatherflow-monitor-worker
+    build:
+      context: './services/monitor/vendor/laravel/sail/runtimes/8.4'
+      dockerfile: Dockerfile
+      args:
+        WWWGROUP: '${WWWGROUP:-1000}'
+    image: 'sail-8.4/monitor'
+    command: php artisan monitor:consume-station-events
+    environment:
+      WWWUSER: '${WWWUSER:-1000}'
+      LARAVEL_SAIL: 1
+    volumes:
+      - './services/monitor:/var/www/html'
+    networks:
+      - weatherflow
+    depends_on:
+      - rabbitmq
+      - mongodb_monitor
+
   rabbitmq:
     container_name: weatherflow-rabbitmq
     image: 'rabbitmq:3-management-alpine'

--- a/services/monitor/app/Application/Messaging/StationRenamedHandler.php
+++ b/services/monitor/app/Application/Messaging/StationRenamedHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Messaging;
+
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+
+final class StationRenamedHandler
+{
+    public function __construct(
+        private readonly MeasurementRepository $measurementRepository,
+    ) {}
+
+    public function handle(array $payload): void
+    {
+        $this->measurementRepository->updateStationNameByStationId(
+            StationId::fromString($payload['station_id']),
+            $payload['new_name'],
+        );
+    }
+}

--- a/services/monitor/app/Console/Commands/ConsumeStationEvents.php
+++ b/services/monitor/app/Console/Commands/ConsumeStationEvents.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Application\Messaging\StationRenamedHandler;
+use App\Domain\Measurement\Repositories\MeasurementRepository;
+use Illuminate\Console\Command;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+
+final class ConsumeStationEvents extends Command
+{
+    protected $signature   = 'monitor:consume-station-events';
+    protected $description = 'Consume station-events from RabbitMQ and sync measurement data';
+
+    public function handle(MeasurementRepository $measurementRepository): void
+    {
+        $handler = new StationRenamedHandler($measurementRepository);
+
+        $connection = new AMQPStreamConnection(
+            host:     config('services.rabbitmq.host'),
+            port:     config('services.rabbitmq.port'),
+            user:     config('services.rabbitmq.user'),
+            password: config('services.rabbitmq.password'),
+        );
+
+        $channel = $connection->channel();
+        $channel->queue_declare('station-events', false, true, false, false);
+
+        $this->info('[monitor] Listening on station-events...');
+
+        $channel->basic_consume(
+            queue:        'station-events',
+            consumer_tag: '',
+            no_local:     false,
+            no_ack:       false,
+            exclusive:    false,
+            nowait:       false,
+            callback:     function (AMQPMessage $message) use ($handler): void {
+                $payload = json_decode($message->body, true);
+
+                if (($payload['event'] ?? null) === 'StationRenamed') {
+                    $handler->handle($payload);
+                    $this->info("[monitor] StationRenamed — station {$payload['station_id']} renamed to '{$payload['new_name']}'");
+                }
+
+                $message->ack();
+            },
+        );
+
+        while ($channel->is_consuming()) {
+            $channel->wait();
+        }
+
+        $channel->close();
+        $connection->close();
+    }
+}

--- a/services/monitor/app/Domain/Measurement/Entities/Measurement.php
+++ b/services/monitor/app/Domain/Measurement/Entities/Measurement.php
@@ -17,7 +17,7 @@ final class Measurement
     private function __construct(
         private readonly MeasurementId      $id,
         private readonly StationId          $stationId,
-        private readonly string             $stationName,
+        private string                      $stationName,
         private Temperature                 $temperature,
         private Humidity                    $humidity,
         private AtmosphericPressure         $atmosphericPressure,
@@ -80,6 +80,11 @@ final class Measurement
     public function stationName(): string
     {
         return $this->stationName;
+    }
+
+    public function renameStation(string $newName): void
+    {
+        $this->stationName = $newName;
     }
 
     public function temperature(): Temperature

--- a/services/monitor/app/Domain/Measurement/Repositories/MeasurementRepository.php
+++ b/services/monitor/app/Domain/Measurement/Repositories/MeasurementRepository.php
@@ -19,5 +19,7 @@ interface MeasurementRepository
 
     public function hasMeasurementsForStation(StationId $stationId): bool;
 
+    public function updateStationNameByStationId(StationId $stationId, string $newName): void;
+
     public function delete(MeasurementId $id): void;
 }

--- a/services/monitor/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
+++ b/services/monitor/app/Infrastructure/Persistence/MongoDB/MongoMeasurementRepository.php
@@ -66,6 +66,12 @@ final class MongoMeasurementRepository implements MeasurementRepository
         return MeasurementModel::where('station_id', $stationId->value())->exists();
     }
 
+    public function updateStationNameByStationId(StationId $stationId, string $newName): void
+    {
+        MeasurementModel::where('station_id', $stationId->value())
+            ->update(['station_name' => $newName]);
+    }
+
     public function delete(MeasurementId $id): void
     {
         MeasurementModel::destroy($id->value());

--- a/services/monitor/tests/Unit/Application/Messaging/StationRenamedHandlerTest.php
+++ b/services/monitor/tests/Unit/Application/Messaging/StationRenamedHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Messaging\StationRenamedHandler;
+use App\Domain\Measurement\Entities\Measurement;
+use App\Domain\Measurement\ValueObjects\AtmosphericPressure;
+use App\Domain\Measurement\ValueObjects\Humidity;
+use App\Domain\Measurement\ValueObjects\MeasurementId;
+use App\Domain\Measurement\ValueObjects\Temperature;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Tests\Unit\Domain\Measurement\FakeMeasurementRepository;
+
+test('updates station_name for all measurements with the given station_id', function () {
+    $stationId    = StationId::fromString('00000000-0000-4000-a000-000000000001');
+    $otherStation = StationId::fromString('00000000-0000-4000-a000-000000000002');
+
+    $m1 = Measurement::create(MeasurementId::generate(), $stationId,    'Nombre Original', new Temperature(20.0), new Humidity(50.0), new AtmosphericPressure(1013.0), new DateTimeImmutable('2026-04-01T10:00:00Z'));
+    $m2 = Measurement::create(MeasurementId::generate(), $stationId,    'Nombre Original', new Temperature(22.0), new Humidity(55.0), new AtmosphericPressure(1010.0), new DateTimeImmutable('2026-04-01T11:00:00Z'));
+    $m3 = Measurement::create(MeasurementId::generate(), $otherStation, 'Otra Estación',   new Temperature(18.0), new Humidity(60.0), new AtmosphericPressure(1005.0), new DateTimeImmutable('2026-04-01T12:00:00Z'));
+
+    $repository = new FakeMeasurementRepository();
+    $repository->seed($m1, $m2, $m3);
+
+    (new StationRenamedHandler($repository))->handle([
+        'event'      => 'StationRenamed',
+        'station_id' => $stationId->value(),
+        'new_name'   => 'Nombre Actualizado',
+    ]);
+
+    expect($m1->stationName())->toBe('Nombre Actualizado')
+        ->and($m2->stationName())->toBe('Nombre Actualizado')
+        ->and($m3->stationName())->toBe('Otra Estación');
+});
+
+test('does nothing when no measurements match the station_id', function () {
+    $repository = new FakeMeasurementRepository();
+
+    (new StationRenamedHandler($repository))->handle([
+        'event'      => 'StationRenamed',
+        'station_id' => '00000000-0000-4000-a000-000000000099',
+        'new_name'   => 'Nombre Actualizado',
+    ]);
+
+    expect($repository->findAll())->toBeEmpty();
+});

--- a/services/monitor/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
+++ b/services/monitor/tests/Unit/Domain/Measurement/FakeMeasurementRepository.php
@@ -42,6 +42,15 @@ final class FakeMeasurementRepository implements MeasurementRepository
         ));
     }
 
+    public function updateStationNameByStationId(StationId $stationId, string $newName): void
+    {
+        foreach ($this->measurements as $measurement) {
+            if ($measurement->stationId()->value() === $stationId->value()) {
+                $measurement->renameStation($newName);
+            }
+        }
+    }
+
     public function delete(MeasurementId $id): void
     {
         unset($this->measurements[$id->value()]);


### PR DESCRIPTION
…iciones #31

- El Monitor ahora escucha la cola station-events de RabbitMQ y actualiza station_name en todos los documentos de medición afectados cuando una estación es renombrada en el Core.

 - El comando Artisan monitor:consume-station-events conecta a RabbitMQ y delega al handler. Se agrega el servicio monitor-worker en compose.yaml para correrlo como proceso dedicado.