### PR TITLE
feat Scheduler de ingesta climática como proceso supervisado en Core

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
       XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
     volumes:
       - './services/core:/var/www/html'
+      - './services/core/docker/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf'
     networks:
       - weatherflow
     depends_on:

--- a/services/core/docker/supervisord.conf
+++ b/services/core/docker/supervisord.conf
@@ -1,0 +1,36 @@
+[supervisord]
+nodaemon=true
+user=root
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:php]
+command=%(ENV_SUPERVISOR_PHP_COMMAND)s
+user=%(ENV_SUPERVISOR_PHP_USER)s
+environment=LARAVEL_SAIL="1"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:scheduler]
+command=php /var/www/html/artisan schedule:work
+user=sail
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/services/core/routes/console.php
+++ b/services/core/routes/console.php
@@ -2,7 +2,11 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('core:ingest-measurements')
+    ->cron(config('services.ingestion.cron'));


### PR DESCRIPTION
- Agrega un supervisord.conf propio que corre el scheduler de Laravel (schedule:work) como segundo proceso dentro del contenedor core, junto al web, sin sumar contenedores nuevos. Se monta sobre el conf de Sail vía compose.

- El schedule registra core:ingest-measurements con el cron leído desde config (INGESTION_CRON), así el intervalo se cambia por env sin tocar código.