### PR TITLE
Feat reporte temperatura actual

### DIFF
--- a/services/core/app/Application/Reports/GetCurrentTemperature/CurrentTemperatureResponse.php
+++ b/services/core/app/Application/Reports/GetCurrentTemperature/CurrentTemperatureResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Reports\GetCurrentTemperature;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use JsonSerializable;
+
+final class CurrentTemperatureResponse implements JsonSerializable
+{
+    public function __construct(
+        public readonly string            $stationId,
+        public readonly string            $stationName,
+        public readonly float             $temperature,
+        public readonly DateTimeImmutable $reportedAt,
+    ) {}
+
+    /**
+     * @return array{station_id: string, station_name: string, temperature: float, reported_at: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'station_id'   => $this->stationId,
+            'station_name' => $this->stationName,
+            'temperature'  => $this->temperature,
+            'reported_at'  => $this->reportedAt
+                ->setTimezone(new DateTimeZone('UTC'))
+                ->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/services/core/app/Application/Reports/GetCurrentTemperature/GetCurrentTemperatureHandler.php
+++ b/services/core/app/Application/Reports/GetCurrentTemperature/GetCurrentTemperatureHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Reports\GetCurrentTemperature;
+
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use App\Infrastructure\Http\Clients\ClimateProviderFactory;
+
+final class GetCurrentTemperatureHandler
+{
+    public function __construct(
+        private readonly WeatherStationRepository $stationRepository,
+        private readonly ClimateProviderFactory   $providerFactory,
+    ) {}
+
+    public function handle(GetCurrentTemperatureQuery $query): CurrentTemperatureResponse
+    {
+        $station = $this->stationRepository->findById(StationId::fromString($query->stationId));
+
+        if ($station === null) {
+            throw new StationNotFoundException($query->stationId);
+        }
+
+        $reading = $this->providerFactory
+            ->for($station->climateProvider())
+            ->fetchCurrentReading($station->location());
+
+        return new CurrentTemperatureResponse(
+            stationId:   $station->id()->value(),
+            stationName: $station->stationName(),
+            temperature: $reading->temperature,
+            reportedAt:  $reading->reportedAt,
+        );
+    }
+}

--- a/services/core/app/Application/Reports/GetCurrentTemperature/GetCurrentTemperatureQuery.php
+++ b/services/core/app/Application/Reports/GetCurrentTemperature/GetCurrentTemperatureQuery.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Reports\GetCurrentTemperature;
+
+final class GetCurrentTemperatureQuery
+{
+    public function __construct(
+        public readonly string $stationId,
+    ) {}
+}

--- a/services/core/app/Infrastructure/Http/Clients/ClimateProviderFactory.php
+++ b/services/core/app/Infrastructure/Http/Clients/ClimateProviderFactory.php
@@ -10,7 +10,7 @@ use App\Domain\WeatherStation\Enums\ClimateProviderType;
 final class ClimateProviderFactory
 {
     public function __construct(
-        private readonly OpenWeatherProvider $openWeatherProvider,
+        private readonly ClimateProvider $openWeatherProvider,
     ) {}
 
     public function for(ClimateProviderType $type): ClimateProvider

--- a/services/core/app/Infrastructure/Http/Controllers/ReportController.php
+++ b/services/core/app/Infrastructure/Http/Controllers/ReportController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Controllers;
+
+use App\Application\Reports\GetCurrentTemperature\GetCurrentTemperatureHandler;
+use App\Application\Reports\GetCurrentTemperature\GetCurrentTemperatureQuery;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use Illuminate\Http\JsonResponse;
+
+final class ReportController
+{
+    public function __construct(
+        private readonly GetCurrentTemperatureHandler $currentTemperatureHandler,
+    ) {}
+
+    public function currentTemperature(string $stationId): JsonResponse
+    {
+        try {
+            return response()->json(
+                $this->currentTemperatureHandler->handle(new GetCurrentTemperatureQuery($stationId)),
+            );
+        } catch (StationNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+}

--- a/services/core/public/docs/openapi.yaml
+++ b/services/core/public/docs/openapi.yaml
@@ -16,6 +16,8 @@ tags:
     description: Gestión de usuarios y sus suscripciones a estaciones
   - name: Weather Stations
     description: Gestión de estaciones meteorológicas
+  - name: Reports
+    description: Consultas de datos climáticos en vivo desde el proveedor
 
 # =============================================================================
 # PATHS
@@ -370,6 +372,54 @@ paths:
                     type: string
               example:
                 message: "Station 660e8400-e29b-41d4-a716-446655440001 has measurements and cannot be deleted."
+
+  # ---------------------------------------------------------------------------
+  # REPORTS
+  # ---------------------------------------------------------------------------
+
+  /reports/current-temp/{stationId}:
+    get:
+      tags: [Reports]
+      summary: Temperatura actual de una estación
+      description: >
+        Consulta en vivo la temperatura actual de la estación llamando al proveedor
+        climático (OpenWeatherMap) en el momento de la request, usando la ubicación
+        de la estación. No lee de la base de mediciones.
+      operationId: getCurrentTemperature
+      parameters:
+        - name: stationId
+          in: path
+          required: true
+          description: UUID de la estación
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Temperatura actual obtenida del proveedor
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  station_id:
+                    type: string
+                    format: uuid
+                  station_name:
+                    type: string
+                  temperature:
+                    type: number
+                    description: Temperatura actual en °C
+                  reported_at:
+                    type: string
+                    format: date-time
+                example:
+                  station_id: "00000000-0000-4000-8000-000000000101"
+                  station_name: "Universidad Nacional de Quilmes"
+                  temperature: 21.4
+                  reported_at: "2026-06-16T15:00:00+00:00"
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 # =============================================================================
 # COMPONENTS

--- a/services/core/routes/api.php
+++ b/services/core/routes/api.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Infrastructure\Http\Controllers\ReportController;
 use App\Infrastructure\Http\Controllers\UserController;
 use App\Infrastructure\Http\Controllers\WeatherStationController;
 use Illuminate\Support\Facades\Route;
@@ -10,3 +11,5 @@ Route::apiResource('users', UserController::class);
 Route::post('users/{userId}/subscriptions', [UserController::class, 'subscribe']);
 Route::delete('users/{userId}/subscriptions/{stationId}', [UserController::class, 'unsubscribe']);
 Route::apiResource('stations', WeatherStationController::class);
+
+Route::get('reports/current-temp/{stationId}', [ReportController::class, 'currentTemperature']);

--- a/services/core/tests/Unit/Application/Reports/GetCurrentTemperature/GetCurrentTemperatureHandlerTest.php
+++ b/services/core/tests/Unit/Application/Reports/GetCurrentTemperature/GetCurrentTemperatureHandlerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Reports\GetCurrentTemperature\CurrentTemperatureResponse;
+use App\Application\Reports\GetCurrentTemperature\GetCurrentTemperatureHandler;
+use App\Application\Reports\GetCurrentTemperature\GetCurrentTemperatureQuery;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\Exceptions\StationNotFoundException;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use App\Infrastructure\Http\Clients\ClimateProviderFactory;
+use Tests\Unit\Domain\WeatherStation\FakeClimateProvider;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+
+test('returns the current temperature for an existing station', function () {
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::generate(),
+        'Universidad Nacional de Quilmes',
+        new Location(-34.7064, -58.2797),
+        'OpenWeatherMap API',
+    );
+
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    $reading = new ClimateReading(21.4, 70.0, 1012.0, new DateTimeImmutable('2026-06-08T15:00:00Z'));
+    $factory = new ClimateProviderFactory(new FakeClimateProvider($reading));
+
+    $response = (new GetCurrentTemperatureHandler($stationRepo, $factory))
+        ->handle(new GetCurrentTemperatureQuery($station->id()->value()));
+
+    expect($response)->toBeInstanceOf(CurrentTemperatureResponse::class)
+        ->and($response->stationId)->toBe($station->id()->value())
+        ->and($response->stationName)->toBe('Universidad Nacional de Quilmes')
+        ->and($response->temperature)->toBe(21.4);
+});
+
+test('throws when the station does not exist', function () {
+    $reading = new ClimateReading(21.4, 70.0, 1012.0, new DateTimeImmutable('2026-06-08T15:00:00Z'));
+    $factory = new ClimateProviderFactory(new FakeClimateProvider($reading));
+
+    (new GetCurrentTemperatureHandler(new FakeWeatherStationRepository(), $factory))
+        ->handle(new GetCurrentTemperatureQuery('00000000-0000-4000-a000-000000000000'));
+})->throws(StationNotFoundException::class);
+
+test('serializes to the documented snake_case contract', function () {
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::generate(),
+        'Bariloche',
+        new Location(-41.1335, -71.3103),
+        'OpenWeatherMap API',
+    );
+
+    $stationRepo = new FakeWeatherStationRepository();
+    $stationRepo->seed($station);
+
+    $reading = new ClimateReading(8.2, 55.0, 1008.0, new DateTimeImmutable('2026-06-08T15:00:00Z'));
+    $factory = new ClimateProviderFactory(new FakeClimateProvider($reading));
+
+    $response = (new GetCurrentTemperatureHandler($stationRepo, $factory))
+        ->handle(new GetCurrentTemperatureQuery($station->id()->value()));
+
+    expect($response->jsonSerialize())
+        ->toBe([
+            'station_id'   => $station->id()->value(),
+            'station_name' => 'Bariloche',
+            'temperature'  => 8.2,
+            'reported_at'  => '2026-06-08T15:00:00+00:00',
+        ]);
+});

--- a/services/core/tests/Unit/Domain/WeatherStation/FakeClimateProvider.php
+++ b/services/core/tests/Unit/Domain/WeatherStation/FakeClimateProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\WeatherStation;
+
+use App\Domain\WeatherStation\Clients\ClimateProvider;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\Location;
+
+final class FakeClimateProvider implements ClimateProvider
+{
+    public function __construct(
+        private readonly ClimateReading $reading,
+    ) {}
+
+    public function fetchCurrentReading(Location $location): ClimateReading
+    {
+        return $this->reading;
+    }
+}


### PR DESCRIPTION
-  Nuevo endpoint GET /api/reports/current-temp/{stationId} que consulta en vivo la temperatura de una estación llamando a OpenWeatherMap en el momento de la request, usando la ubicación de la estación. Reutiliza el ClimateProvider y el factory de la ingesta. Si la estación no existe devuelve 404; no toca la base de mediciones.