### PR TITLE
feat/frontend-reportes-promedios

### DIFF
--- a/services/frontend/app.js
+++ b/services/frontend/app.js
@@ -4,6 +4,7 @@ import { state } from './state.js';
 import { loadMeasurements, currentFilters, openNewMeasurementModal } from './measurements.js';
 import { loadStations, openNewStationModal, currentStationFilters } from './stations.js';
 import { loadUsers, openNewUserModal } from './users.js';
+import './reports.js';
 
 async function preload() {
   try {

--- a/services/frontend/reports.js
+++ b/services/frontend/reports.js
@@ -1,0 +1,44 @@
+import { MONITOR, apiGet } from './api.js';
+import { openModal, closeModal, toast, fmtDate } from './ui.js';
+
+export async function openStationReportsModal(station) {
+  openModal(`Reports — ${station.stationName}`, '<div class="loading">Loading…</div>');
+  try {
+    const [daily, weekly] = await Promise.all([
+      apiGet(`${MONITOR}/reports/avg/day?station_id=${station.id}`),
+      apiGet(`${MONITOR}/reports/avg/week?station_id=${station.id}`),
+    ]);
+    document.getElementById('modal-body').innerHTML = renderReports(daily, weekly);
+  } catch (err) {
+    toast(err.message, 'err');
+    closeModal();
+  }
+}
+
+function renderReports(daily, weekly) {
+  return `
+    <div class="form">
+      ${reportBlock('Daily average (last 24 h)', daily)}
+      ${reportBlock('Weekly average (last 7 days)', weekly)}
+      <div class="form-actions">
+        <button type="button" class="btn btn-ghost" onclick="closeModal()">Close</button>
+      </div>
+    </div>
+  `;
+}
+
+function reportBlock(label, report) {
+  const value = report.averageTemperature === null
+    ? `<div class="dim">${report.message ?? 'No measurements in this window.'}</div>`
+    : `<div class="mono">${report.averageTemperature.toFixed(1)} °C</div>`;
+
+  return `
+    <div class="form-group">
+      <label>${label}</label>
+      ${value}
+      <div class="dim mono">${fmtDate(report.from)} → ${fmtDate(report.to)}</div>
+    </div>
+  `;
+}
+
+window.openStationReportsModal = openStationReportsModal;

--- a/services/frontend/stations.js
+++ b/services/frontend/stations.js
@@ -62,6 +62,7 @@ function renderStations(el, list) {
               <td class="dim mono">${shortId(s.ownerId)}</td>
               <td>
                 <div class="actions">
+                  <button class="btn btn-sm btn-secondary" onclick='openStationReportsModal(${JSON.stringify(s)})'>Reports</button>
                   <button class="btn btn-sm btn-secondary" onclick='openEditStationModal(${JSON.stringify(s)})'>Edit</button>
                   <button class="btn btn-sm btn-danger"    onclick="deleteStation('${s.id}')">Delete</button>
                 </div>


### PR DESCRIPTION
- Agrega un botón Reports por estación en el listado, que abre un modal de solo lectura con el promedio de temperatura de las últimas 24 h y de los últimos 7 días, consultando los endpoints de Monitor ya existentes.