### PR TITLE
Feat/select de proveedor climático en alta y edición de estación

### DIFF
--- a/services/core/database/seeders/DefaultStationsSeeder.php
+++ b/services/core/database/seeders/DefaultStationsSeeder.php
@@ -9,8 +9,6 @@ use App\Domain\User\Repositories\UserRepository;
 use App\Domain\User\ValueObjects\Email;
 use App\Domain\User\ValueObjects\UserId;
 use App\Domain\WeatherStation\Entities\WeatherStation;
-use App\Domain\WeatherStation\Enums\ClimateProviderType;
-use App\Domain\WeatherStation\Enums\StationStatus;
 use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
 use App\Domain\WeatherStation\ValueObjects\Location;
 use App\Domain\WeatherStation\ValueObjects\StationId;
@@ -25,26 +23,29 @@ final class DefaultStationsSeeder extends Seeder
      * domain repositories performs an updateOrCreate by _id, so re-running
      * never duplicates rows.
      *
-     * @var list<array{id: string, name: string, latitude: float, longitude: float}>
+     * @var list<array{id: string, name: string, latitude: float, longitude: float, sensorModel: string}>
      */
     private const STATIONS = [
         [
-            'id'        => '00000000-0000-4000-8000-000000000101',
-            'name'      => 'Universidad Nacional de Quilmes',
-            'latitude'  => -34.7064,
-            'longitude' => -58.2797,
+            'id'          => '00000000-0000-4000-8000-000000000101',
+            'name'        => 'Universidad Nacional de Quilmes',
+            'latitude'    => -34.7064,
+            'longitude'   => -58.2797,
+            'sensorModel' => 'Davis Vantage Pro2',
         ],
         [
-            'id'        => '00000000-0000-4000-8000-000000000102',
-            'name'      => 'Bariloche',
-            'latitude'  => -41.1335,
-            'longitude' => -71.3103,
+            'id'          => '00000000-0000-4000-8000-000000000102',
+            'name'        => 'Bariloche',
+            'latitude'    => -41.1335,
+            'longitude'   => -71.3103,
+            'sensorModel' => 'Vaisala WXT536',
         ],
         [
-            'id'        => '00000000-0000-4000-8000-000000000103',
-            'name'      => 'Ushuaia',
-            'latitude'  => -54.8019,
-            'longitude' => -68.3030,
+            'id'          => '00000000-0000-4000-8000-000000000103',
+            'name'        => 'Ushuaia',
+            'latitude'    => -54.8019,
+            'longitude'   => -68.3030,
+            'sensorModel' => 'Campbell Scientific MetSENS500',
         ],
     ];
 
@@ -65,7 +66,7 @@ final class DefaultStationsSeeder extends Seeder
                 $systemUserId,
                 $station['name'],
                 new Location($station['latitude'], $station['longitude']),
-                'OpenWeatherMap API'
+                $station['sensorModel']
             ));
         }
     }

--- a/services/frontend/app.js
+++ b/services/frontend/app.js
@@ -4,6 +4,7 @@ import { state } from './state.js';
 import { loadMeasurements, currentFilters, openNewMeasurementModal } from './measurements.js';
 import { loadStations, openNewStationModal, currentStationFilters } from './stations.js';
 import { loadUsers, openNewUserModal } from './users.js';
+import './reports.js';
 
 async function preload() {
   try {

--- a/services/frontend/reports.js
+++ b/services/frontend/reports.js
@@ -1,0 +1,44 @@
+import { MONITOR, apiGet } from './api.js';
+import { openModal, closeModal, toast, fmtDate } from './ui.js';
+
+export async function openStationReportsModal(station) {
+  openModal(`Reports — ${station.stationName}`, '<div class="loading">Loading…</div>');
+  try {
+    const [daily, weekly] = await Promise.all([
+      apiGet(`${MONITOR}/reports/avg/day?station_id=${station.id}`),
+      apiGet(`${MONITOR}/reports/avg/week?station_id=${station.id}`),
+    ]);
+    document.getElementById('modal-body').innerHTML = renderReports(daily, weekly);
+  } catch (err) {
+    toast(err.message, 'err');
+    closeModal();
+  }
+}
+
+function renderReports(daily, weekly) {
+  return `
+    <div class="form">
+      ${reportBlock('Daily average (last 24 h)', daily)}
+      ${reportBlock('Weekly average (last 7 days)', weekly)}
+      <div class="form-actions">
+        <button type="button" class="btn btn-ghost" onclick="closeModal()">Close</button>
+      </div>
+    </div>
+  `;
+}
+
+function reportBlock(label, report) {
+  const value = report.averageTemperature === null
+    ? `<div class="dim">${report.message ?? 'No measurements in this window.'}</div>`
+    : `<div class="mono">${report.averageTemperature.toFixed(1)} °C</div>`;
+
+  return `
+    <div class="form-group">
+      <label>${label}</label>
+      ${value}
+      <div class="dim mono">${fmtDate(report.from)} → ${fmtDate(report.to)}</div>
+    </div>
+  `;
+}
+
+window.openStationReportsModal = openStationReportsModal;

--- a/services/frontend/stations.js
+++ b/services/frontend/stations.js
@@ -62,6 +62,7 @@ function renderStations(el, list) {
               <td class="dim mono">${shortId(s.ownerId)}</td>
               <td>
                 <div class="actions">
+                  <button class="btn btn-sm btn-secondary" onclick='openStationReportsModal(${JSON.stringify(s)})'>Reports</button>
                   <button class="btn btn-sm btn-secondary" onclick='openEditStationModal(${JSON.stringify(s)})'>Edit</button>
                   <button class="btn btn-sm btn-danger"    onclick="deleteStation('${s.id}')">Delete</button>
                 </div>

--- a/services/frontend/stations.js
+++ b/services/frontend/stations.js
@@ -2,6 +2,16 @@ import { CORE, apiGet, apiPost, apiPut, apiDel } from './api.js';
 import { toast, openModal, closeModal, shortId, fmtDate } from './ui.js';
 import { state, userOptions } from './state.js';
 
+const CLIMATE_PROVIDERS = [
+  { value: 'openweather', label: 'OpenWeather' },
+];
+
+function climateProviderOptions(selected = 'openweather') {
+  return CLIMATE_PROVIDERS
+    .map(p => `<option value="${p.value}" ${p.value === selected ? 'selected' : ''}>${p.label}</option>`)
+    .join('');
+}
+
 export async function loadStations(filters = {}) {
   const el = document.getElementById('stations-list');
   el.innerHTML = '<div class="loading">Loading…</div>';
@@ -107,6 +117,12 @@ export function openNewStationModal() {
         <label>Sensor Model</label>
         <input type="text" name="sensor_model" required placeholder="Davis Vantage Pro2">
       </div>
+      <div class="form-group">
+        <label>Climate Provider</label>
+        <select name="climate_provider" required>
+          ${climateProviderOptions()}
+        </select>
+      </div>
       <div class="form-actions">
         <button type="button" class="btn btn-ghost" onclick="closeModal()">Cancel</button>
         <button type="submit" class="btn btn-primary">Create</button>
@@ -115,11 +131,12 @@ export function openNewStationModal() {
   `, async (fd) => {
     try {
       await apiPost(`${CORE}/stations`, {
-        owner_id:     fd.get('owner_id'),
-        station_name: fd.get('station_name'),
-        latitude:     parseFloat(fd.get('latitude')),
-        longitude:    parseFloat(fd.get('longitude')),
-        sensor_model: fd.get('sensor_model'),
+        owner_id:         fd.get('owner_id'),
+        station_name:     fd.get('station_name'),
+        latitude:         parseFloat(fd.get('latitude')),
+        longitude:        parseFloat(fd.get('longitude')),
+        sensor_model:     fd.get('sensor_model'),
+        climate_provider: fd.get('climate_provider'),
       });
       toast('Station created');
       closeModal();
@@ -170,6 +187,12 @@ export function openEditStationModal(station) {
           </select>
         </div>
       </div>
+      <div class="form-group">
+        <label>Climate Provider</label>
+        <select name="climate_provider" required>
+          ${climateProviderOptions(station.climateProvider)}
+        </select>
+      </div>
       <div class="form-actions">
         <button type="button" class="btn btn-ghost" onclick="closeModal()">Cancel</button>
         <button type="submit" class="btn btn-primary">Save</button>
@@ -178,12 +201,13 @@ export function openEditStationModal(station) {
   `, async (fd) => {
     try {
       await apiPut(`${CORE}/stations/${station.id}`, {
-        owner_id:     fd.get('owner_id'),
-        station_name: fd.get('station_name'),
-        latitude:     parseFloat(fd.get('latitude')),
-        longitude:    parseFloat(fd.get('longitude')),
-        sensor_model: fd.get('sensor_model'),
-        status:       fd.get('status'),
+        owner_id:         fd.get('owner_id'),
+        station_name:     fd.get('station_name'),
+        latitude:         parseFloat(fd.get('latitude')),
+        longitude:        parseFloat(fd.get('longitude')),
+        sensor_model:     fd.get('sensor_model'),
+        status:           fd.get('status'),
+        climate_provider: fd.get('climate_provider'),
       });
       toast('Station updated');
       closeModal();


### PR DESCRIPTION
Feat Select de proveedor climático en alta y edición de estación
- El frontend ahora muestra un select de climate_provider en el alta y la edición de estación y lo envía explícitamente, en vez de depender del default del backend. Deja la UI lista para múltiples proveedores (hoy solo OpenWeather).

 - Además, el seeder de estaciones default asigna un modelo de sensor distinto a cada estación (Davis / Vaisala / Campbell) en lugar de repetir el mismo nombre en las tres.