### PR TITLE
Feat Recordar la última lectura de clima de cada estación

### DIFF
--- a/services/core/app/Application/Contracts/LastReadingCache.php
+++ b/services/core/app/Application/Contracts/LastReadingCache.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Contracts;
+
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+
+interface LastReadingCache
+{
+    public function put(StationId $stationId, ClimateReading $reading): void;
+
+    public function get(StationId $stationId): ?ClimateReading;
+}

--- a/services/core/app/Application/IngestMeasurements/IngestMeasurementsHandler.php
+++ b/services/core/app/Application/IngestMeasurements/IngestMeasurementsHandler.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Application\IngestMeasurements;
 
 use App\Application\Contracts\EventPublisher;
+use App\Application\Contracts\LastReadingCache;
 use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\StationId;
 use App\Infrastructure\Http\Clients\ClimateProviderFactory;
 use DateTimeZone;
 use Illuminate\Support\Facades\Log;
@@ -15,41 +18,61 @@ final class IngestMeasurementsHandler
 {
     public function __construct(
         private readonly WeatherStationRepository $stationRepository,
-        private readonly ClimateProviderFactory   $providerFactory,
-        private readonly EventPublisher           $eventPublisher,
-        private readonly string                   $rawMeasurementsQueue,
+        private readonly ClimateProviderFactory $providerFactory,
+        private readonly EventPublisher $eventPublisher,
+        private readonly LastReadingCache $lastReadingCache,
+        private readonly string $rawMeasurementsQueue,
     ) {}
 
     public function handle(): void
     {
         foreach ($this->stationRepository->findAll() as $station) {
-            $traceId = 'ingest-' . bin2hex(random_bytes(8));
+            $traceId = 'ingest-'.bin2hex(random_bytes(8));
 
             try {
                 $provider = $this->providerFactory->for($station->climateProvider());
-                $reading  = $provider->fetchCurrentReading($station->location());
+                $reading = $provider->fetchCurrentReading($station->location());
+
+                $this->cacheLastReading($station->id(), $reading, $traceId);
 
                 $this->eventPublisher->publish($this->rawMeasurementsQueue, [
-                    'event'                => 'RawMeasurementIngested',
-                    'station_id'           => $station->id()->value(),
-                    'station_name'         => $station->stationName(),
-                    'provider'             => $station->climateProvider()->value,
-                    'temperature'          => $reading->temperature,
-                    'humidity'             => $reading->humidity,
+                    'event' => 'RawMeasurementIngested',
+                    'station_id' => $station->id()->value(),
+                    'station_name' => $station->stationName(),
+                    'provider' => $station->climateProvider()->value,
+                    'temperature' => $reading->temperature,
+                    'humidity' => $reading->humidity,
                     'atmospheric_pressure' => $reading->atmosphericPressure,
-                    'reported_at'          => $reading->reportedAt
+                    'reported_at' => $reading->reportedAt
                         ->setTimezone(new DateTimeZone('UTC'))
                         ->format('Y-m-d\TH:i:s\Z'),
-                    'trace_id'             => $traceId,
+                    'trace_id' => $traceId,
                 ]);
             } catch (Throwable $exception) {
                 Log::error('Failed to ingest measurement for station', [
                     'station_id' => $station->id()->value(),
-                    'provider'   => $station->climateProvider()->value,
-                    'trace_id'   => $traceId,
-                    'error'      => $exception->getMessage(),
+                    'provider' => $station->climateProvider()->value,
+                    'trace_id' => $traceId,
+                    'error' => $exception->getMessage(),
                 ]);
             }
+        }
+    }
+
+    /**
+     * Write-through cache of the last successful reading. A cache failure must not
+     * abort the ingestion or the message publication, so it is logged and swallowed.
+     */
+    private function cacheLastReading(StationId $stationId, ClimateReading $reading, string $traceId): void
+    {
+        try {
+            $this->lastReadingCache->put($stationId, $reading);
+        } catch (Throwable $cacheException) {
+            Log::warning('Failed to cache last reading for station', [
+                'station_id' => $stationId->value(),
+                'trace_id' => $traceId,
+                'error' => $cacheException->getMessage(),
+            ]);
         }
     }
 }

--- a/services/core/app/Infrastructure/Cache/RedisLastReadingCache.php
+++ b/services/core/app/Infrastructure/Cache/RedisLastReadingCache.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Cache;
+
+use App\Application\Contracts\LastReadingCache;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Support\Facades\Redis;
+
+final class RedisLastReadingCache implements LastReadingCache
+{
+    public function put(StationId $stationId, ClimateReading $reading): void
+    {
+        Redis::setex(
+            $this->keyFor($stationId),
+            config('services.resilience.owm_cache_ttl'),
+            $this->serialize($reading),
+        );
+    }
+
+    public function get(StationId $stationId): ?ClimateReading
+    {
+        $payload = Redis::get($this->keyFor($stationId));
+
+        // Missing keys come back as false (phpredis) or null (predis).
+        if (! is_string($payload)) {
+            return null;
+        }
+
+        return $this->deserialize($payload);
+    }
+
+    private function keyFor(StationId $stationId): string
+    {
+        return "owm:last:{$stationId->value()}";
+    }
+
+    private function serialize(ClimateReading $reading): string
+    {
+        return json_encode([
+            'temperature' => $reading->temperature,
+            'humidity' => $reading->humidity,
+            'atmospheric_pressure' => $reading->atmosphericPressure,
+            'reported_at' => $reading->reportedAt
+                ->setTimezone(new DateTimeZone('UTC'))
+                ->format('Y-m-d\TH:i:s\Z'),
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function deserialize(string $payload): ClimateReading
+    {
+        $data = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);
+
+        return new ClimateReading(
+            temperature: (float) $data['temperature'],
+            humidity: (float) $data['humidity'],
+            atmosphericPressure: (float) $data['atmospheric_pressure'],
+            reportedAt: new DateTimeImmutable($data['reported_at']),
+        );
+    }
+}

--- a/services/core/app/Providers/AppServiceProvider.php
+++ b/services/core/app/Providers/AppServiceProvider.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Application\Contracts\EventPublisher;
+use App\Application\Contracts\LastReadingCache;
 use App\Application\IngestMeasurements\IngestMeasurementsHandler;
 use App\Application\WeatherStation\UpdateStation\UpdateStationHandler;
 use App\Domain\User\Repositories\UserRepository;
 use App\Domain\WeatherStation\Repositories\WeatherStationRepository;
+use App\Infrastructure\Cache\RedisLastReadingCache;
 use App\Infrastructure\Http\Clients\ClimateProviderFactory;
 use App\Infrastructure\Http\Clients\OpenWeatherProvider;
 use App\Infrastructure\Messaging\RabbitMQEventPublisher;
@@ -23,6 +25,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(UserRepository::class, MongoUserRepository::class);
         $this->app->bind(WeatherStationRepository::class, MongoWeatherStationRepository::class);
         $this->app->bind(EventPublisher::class, RabbitMQEventPublisher::class);
+        $this->app->singleton(LastReadingCache::class, RedisLastReadingCache::class);
 
         $this->app->bind(UpdateStationHandler::class, function ($app) {
             return new UpdateStationHandler(
@@ -45,6 +48,7 @@ class AppServiceProvider extends ServiceProvider
                 $app->make(WeatherStationRepository::class),
                 $app->make(ClimateProviderFactory::class),
                 $app->make(EventPublisher::class),
+                $app->make(LastReadingCache::class),
                 config('services.queues.raw_measurements'),
             );
         });

--- a/services/core/phpunit.xml
+++ b/services/core/phpunit.xml
@@ -33,5 +33,6 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
         <env name="MONGODB_DATABASE" value="weatherflow_test"/>
+        <env name="REDIS_DB" value="15"/>
     </php>
 </phpunit>

--- a/services/core/tests/Integration/Cache/LastReadingCacheTest.php
+++ b/services/core/tests/Integration/Cache/LastReadingCacheTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\Contracts\LastReadingCache;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use Illuminate\Support\Facades\Redis;
+
+// These tests hit a real Redis. phpunit.xml pins the connection to logical DB 15 so
+// they never touch the app's data on DB 0; afterEach flushes that test-only database.
+
+beforeEach(function () {
+    try {
+        Redis::connection()->ping();
+    } catch (Throwable $exception) {
+        $this->markTestSkipped('Redis is not reachable: '.$exception->getMessage());
+    }
+});
+
+afterEach(function () {
+    Redis::connection()->flushdb();
+});
+
+test('stores and retrieves a reading round-trip', function () {
+    $cache = app(LastReadingCache::class);
+    $stationId = StationId::generate();
+    $reading = new ClimateReading(21.4, 70.0, 1012.0, new DateTimeImmutable('2026-06-29T14:50:00Z'));
+
+    $cache->put($stationId, $reading);
+    $restored = $cache->get($stationId);
+
+    expect($restored)->toBeInstanceOf(ClimateReading::class)
+        ->and($restored->temperature)->toBe(21.4)
+        ->and($restored->humidity)->toBe(70.0)
+        ->and($restored->atmosphericPressure)->toBe(1012.0)
+        ->and($restored->reportedAt->format('Y-m-d\TH:i:s\Z'))->toBe('2026-06-29T14:50:00Z');
+});
+
+test('returns null when nothing was cached for the station', function () {
+    expect(app(LastReadingCache::class)->get(StationId::generate()))->toBeNull();
+});
+
+test('sets a TTL taken from config on the cached reading', function () {
+    config(['services.resilience.owm_cache_ttl' => 600]);
+    $stationId = StationId::generate();
+
+    app(LastReadingCache::class)->put($stationId, new ClimateReading(20.0, 50.0, 1000.0, new DateTimeImmutable));
+
+    $ttl = Redis::connection()->ttl("owm:last:{$stationId->value()}");
+
+    expect($ttl)->toBeGreaterThan(0)
+        ->and($ttl)->toBeLessThanOrEqual(600);
+});
+
+test('overwrites the previous reading for the same station', function () {
+    $cache = app(LastReadingCache::class);
+    $stationId = StationId::generate();
+
+    $cache->put($stationId, new ClimateReading(10.0, 40.0, 990.0, new DateTimeImmutable));
+    $cache->put($stationId, new ClimateReading(25.5, 60.0, 1015.0, new DateTimeImmutable));
+
+    expect($cache->get($stationId)->temperature)->toBe(25.5);
+});

--- a/services/core/tests/Unit/Application/IngestMeasurements/IngestMeasurementsHandlerTest.php
+++ b/services/core/tests/Unit/Application/IngestMeasurements/IngestMeasurementsHandlerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Application\IngestMeasurements\IngestMeasurementsHandler;
+use App\Domain\User\ValueObjects\UserId;
+use App\Domain\WeatherStation\Clients\ClimateProvider;
+use App\Domain\WeatherStation\Entities\WeatherStation;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\Location;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use App\Infrastructure\Http\Clients\ClimateProviderFactory;
+use Tests\TestCase;
+use Tests\Unit\Domain\WeatherStation\FakeClimateProvider;
+use Tests\Unit\Domain\WeatherStation\FakeWeatherStationRepository;
+use Tests\Unit\Infrastructure\Cache\FakeLastReadingCache;
+use Tests\Unit\Infrastructure\Cache\FaultyLastReadingCache;
+use Tests\Unit\Infrastructure\Messaging\FakeEventPublisher;
+
+uses(TestCase::class);
+
+test('caches the reading and publishes the measurement on a successful tick', function () {
+    $repository = new FakeWeatherStationRepository;
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(-34.9, -58.3),
+        'Sensor 1',
+    );
+    $repository->seed($station);
+
+    $reading = new ClimateReading(21.4, 70.0, 1012.0, new DateTimeImmutable);
+    $factory = new ClimateProviderFactory(new FakeClimateProvider($reading));
+    $publisher = new FakeEventPublisher;
+    $cache = new FakeLastReadingCache;
+
+    (new IngestMeasurementsHandler($repository, $factory, $publisher, $cache, 'raw-measurements'))->handle();
+
+    expect($cache->wasPut($station->id()))->toBeTrue()
+        ->and($cache->get($station->id()))->toBe($reading)
+        ->and($publisher->wasPublishedTo('raw-measurements'))->toBeTrue();
+});
+
+test('a cache write failure does not abort ingestion or publishing', function () {
+    $repository = new FakeWeatherStationRepository;
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(-34.9, -58.3),
+        'Sensor 1',
+    );
+    $repository->seed($station);
+
+    $reading = new ClimateReading(21.4, 70.0, 1012.0, new DateTimeImmutable);
+    $factory = new ClimateProviderFactory(new FakeClimateProvider($reading));
+    $publisher = new FakeEventPublisher;
+
+    (new IngestMeasurementsHandler($repository, $factory, $publisher, new FaultyLastReadingCache, 'raw-measurements'))->handle();
+
+    expect($publisher->wasPublishedTo('raw-measurements'))->toBeTrue();
+});
+
+test('does not cache or publish when the provider fails', function () {
+    $repository = new FakeWeatherStationRepository;
+    $station = WeatherStation::create(
+        StationId::generate(),
+        UserId::fromString('00000000-0000-4000-a000-000000000001'),
+        'Estación Central',
+        new Location(-34.9, -58.3),
+        'Sensor 1',
+    );
+    $repository->seed($station);
+
+    $failingProvider = new class implements ClimateProvider
+    {
+        public function fetchCurrentReading(Location $location): ClimateReading
+        {
+            throw new RuntimeException('OWM is down');
+        }
+    };
+    $factory = new ClimateProviderFactory($failingProvider);
+    $publisher = new FakeEventPublisher;
+    $cache = new FakeLastReadingCache;
+
+    (new IngestMeasurementsHandler($repository, $factory, $publisher, $cache, 'raw-measurements'))->handle();
+
+    expect($cache->getPutCount())->toBe(0)
+        ->and($publisher->wasPublishedTo('raw-measurements'))->toBeFalse();
+});
+
+test('a provider failure on one station does not stop caching and publishing the others', function () {
+    $repository = new FakeWeatherStationRepository;
+    $ownerId = UserId::fromString('00000000-0000-4000-a000-000000000001');
+    $failingStation = WeatherStation::create(StationId::generate(), $ownerId, 'Falla', new Location(-1.0, 0.0), 'Sensor 1');
+    $workingStation = WeatherStation::create(StationId::generate(), $ownerId, 'Anda', new Location(0.0, 0.0), 'Sensor 2');
+    $repository->seed($failingStation, $workingStation);
+
+    $reading = new ClimateReading(21.4, 70.0, 1012.0, new DateTimeImmutable);
+    $provider = new class($reading) implements ClimateProvider
+    {
+        public function __construct(private readonly ClimateReading $reading) {}
+
+        public function fetchCurrentReading(Location $location): ClimateReading
+        {
+            if ($location->latitude() === -1.0) {
+                throw new RuntimeException('OWM is down for this station');
+            }
+
+            return $this->reading;
+        }
+    };
+    $factory = new ClimateProviderFactory($provider);
+    $publisher = new FakeEventPublisher;
+    $cache = new FakeLastReadingCache;
+
+    (new IngestMeasurementsHandler($repository, $factory, $publisher, $cache, 'raw-measurements'))->handle();
+
+    expect($cache->wasPut($workingStation->id()))->toBeTrue()
+        ->and($cache->wasPut($failingStation->id()))->toBeFalse()
+        ->and($cache->getPutCount())->toBe(1)
+        ->and($publisher->getPublishedTo('raw-measurements'))->toHaveCount(1);
+});

--- a/services/core/tests/Unit/Infrastructure/Cache/FakeLastReadingCache.php
+++ b/services/core/tests/Unit/Infrastructure/Cache/FakeLastReadingCache.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\Cache;
+
+use App\Application\Contracts\LastReadingCache;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+
+final class FakeLastReadingCache implements LastReadingCache
+{
+    /** @var array<string, ClimateReading> */
+    private array $readings = [];
+
+    private int $putCount = 0;
+
+    public function put(StationId $stationId, ClimateReading $reading): void
+    {
+        $this->readings[$stationId->value()] = $reading;
+        $this->putCount++;
+    }
+
+    public function get(StationId $stationId): ?ClimateReading
+    {
+        return $this->readings[$stationId->value()] ?? null;
+    }
+
+    public function wasPut(StationId $stationId): bool
+    {
+        return isset($this->readings[$stationId->value()]);
+    }
+
+    public function getPutCount(): int
+    {
+        return $this->putCount;
+    }
+}

--- a/services/core/tests/Unit/Infrastructure/Cache/FaultyLastReadingCache.php
+++ b/services/core/tests/Unit/Infrastructure/Cache/FaultyLastReadingCache.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\Cache;
+
+use App\Application\Contracts\LastReadingCache;
+use App\Domain\WeatherStation\ValueObjects\ClimateReading;
+use App\Domain\WeatherStation\ValueObjects\StationId;
+use RuntimeException;
+
+/**
+ * Simulates Redis being unavailable: every write blows up. Used to prove the
+ * ingestion keeps going (logs and publishes) when the cache cannot be written.
+ */
+final class FaultyLastReadingCache implements LastReadingCache
+{
+    public function put(StationId $stationId, ClimateReading $reading): void
+    {
+        throw new RuntimeException('Redis is unavailable');
+    }
+
+    public function get(StationId $stationId): ?ClimateReading
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
-  La ingesta guarda la lectura tras un fetch exitoso y antes de publicar; si Redis falla, se loguea y se sigue (no aborta ingesta ni publicación). Los tests se aíslan en la DB lógica 15 de Redis para no tocar los datos de la app.