### PR TITLE
Feat Stack Docker: Prometheus, Grafana, Loki, Tempo, OTel Collector

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -139,9 +139,120 @@ services:
     ports:
       - '5672:5672'
       - '15672:15672'
+    expose:
+      - '15692'
     environment:
       RABBITMQ_DEFAULT_USER: weatherflow
       RABBITMQ_DEFAULT_PASS: secret
+    volumes:
+      - './observability/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins:ro'
+      - './observability/rabbitmq/20-prometheus.conf:/etc/rabbitmq/conf.d/20-prometheus.conf:ro'
+    networks:
+      - weatherflow
+
+  prometheus:
+    container_name: weatherflow-prometheus
+    image: 'prom/prometheus:v2.53.1'
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    ports:
+      - '9090:9090'
+    volumes:
+      - './observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro'
+      - 'prometheus-data:/prometheus'
+    networks:
+      - weatherflow
+
+  grafana:
+    container_name: weatherflow-grafana
+    image: 'grafana/grafana:11.1.0'
+    ports:
+      # 3001 en el host: el 3000 lo ocupa el frontend nginx.
+      - '3001:3000'
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - './observability/grafana/provisioning:/etc/grafana/provisioning:ro'
+      - 'grafana-data:/var/lib/grafana'
+    networks:
+      - weatherflow
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
+
+  loki:
+    container_name: weatherflow-loki
+    image: 'grafana/loki:3.1.0'
+    command: '-config.file=/etc/loki/loki-config.yaml'
+    volumes:
+      - './observability/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro'
+      - 'loki-data:/loki'
+    networks:
+      - weatherflow
+
+  promtail:
+    container_name: weatherflow-promtail
+    image: 'grafana/promtail:3.1.0'
+    command: '-config.file=/etc/promtail/promtail-config.yaml'
+    volumes:
+      - './observability/promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro'
+      - '/var/lib/docker/containers:/var/lib/docker/containers:ro'
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+    networks:
+      - weatherflow
+    depends_on:
+      - loki
+
+  tempo:
+    container_name: weatherflow-tempo
+    image: 'grafana/tempo:2.5.0'
+    command: '-config.file=/etc/tempo/tempo-config.yaml'
+    # La imagen corre como uid 10001, que no puede escribir el volumen recién creado.
+    user: root
+    volumes:
+      - './observability/tempo/tempo-config.yaml:/etc/tempo/tempo-config.yaml:ro'
+      - 'tempo-data:/var/tempo'
+    networks:
+      - weatherflow
+
+  otel-collector:
+    container_name: weatherflow-otel-collector
+    image: 'otel/opentelemetry-collector-contrib:0.104.0'
+    command: '--config=/etc/otelcol/config.yaml'
+    expose:
+      - '4317'
+      - '4318'
+      - '8888'
+    volumes:
+      - './observability/otel-collector/config.yaml:/etc/otelcol/config.yaml:ro'
+    networks:
+      - weatherflow
+    depends_on:
+      - tempo
+
+  cadvisor:
+    container_name: weatherflow-cadvisor
+    image: 'gcr.io/cadvisor/cadvisor:v0.49.1'
+    privileged: true
+    volumes:
+      - '/:/rootfs:ro'
+      - '/var/run:/var/run:ro'
+      - '/sys:/sys:ro'
+      - '/var/lib/docker:/var/lib/docker:ro'
+    networks:
+      - weatherflow
+
+  node-exporter:
+    container_name: weatherflow-node-exporter
+    image: 'prom/node-exporter:v1.8.1'
+    command:
+      - '--path.rootfs=/host'
+    volumes:
+      - '/:/host:ro'
     networks:
       - weatherflow
 
@@ -153,4 +264,12 @@ volumes:
   core-mongodb-data:
     driver: local
   monitor-mongodb-data:
+    driver: local
+  prometheus-data:
+    driver: local
+  grafana-data:
+    driver: local
+  loki-data:
+    driver: local
+  tempo-data:
     driver: local

--- a/observability/grafana/provisioning/datasources/loki.yaml
+++ b/observability/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/observability/grafana/provisioning/datasources/prometheus.yaml
+++ b/observability/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/observability/grafana/provisioning/datasources/tempo.yaml
+++ b/observability/grafana/provisioning/datasources/tempo.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200

--- a/observability/loki/loki-config.yaml
+++ b/observability/loki/loki-config.yaml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true

--- a/observability/otel-collector/config.yaml
+++ b/observability/otel-collector/config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,35 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # Apps PHP: DOWN hasta que exista el endpoint /metrics (issue siguiente).
+  - job_name: core
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['core:80']
+
+  - job_name: monitor
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['monitor:80']
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: rabbitmq
+    static_configs:
+      - targets: ['rabbitmq:15692']
+
+  - job_name: otel-collector
+    static_configs:
+      - targets: ['otel-collector:8888']

--- a/observability/promtail/promtail-config.yaml
+++ b/observability/promtail/promtail-config.yaml
@@ -1,0 +1,16 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: placeholder
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: placeholder
+          __path__: /var/log/*.log

--- a/observability/rabbitmq/20-prometheus.conf
+++ b/observability/rabbitmq/20-prometheus.conf
@@ -1,0 +1,3 @@
+# Series por objeto (p. ej. rabbitmq_queue_messages{queue="raw-measurements"});
+# sin esto el plugin solo expone agregados globales.
+prometheus.return_per_object_metrics = true

--- a/observability/rabbitmq/enabled_plugins
+++ b/observability/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management,rabbitmq_prometheus].

--- a/observability/tempo/tempo-config.yaml
+++ b/observability/tempo/tempo-config.yaml
@@ -1,0 +1,23 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 48h


### PR DESCRIPTION
Levanta la infraestructura base, compartida luego con el dashboard de la Etapa 5: Prometheus scrapeando apps y exporters, Grafana con los tres datasources provisionados, Loki/Promtail para logs, Tempo para traces y el Collector como punto de entrada OTLP. Las apps PHP todavía no se instrumentan: sus targets quedan DOWN hasta que exista /metrics.

Decisiones no obvias:

- Para las métricas de RabbitMQ se habilita el plugin nativo rabbitmq_prometheus con return_per_object_metrics (series por cola) en vez de sumar un contenedor exporter aparte.
- Grafana se mapea a 3001 porque el 3000 del host lo ocupa el frontend.
- Tempo corre como root: la imagen usa uid 10001, que no puede escribir el volumen nombrado recién creado.
- La config de Promtail es un esqueleto para que el contenedor levante; el scrape real de contenedores llega con la issue de log aggregation.