### PR TITLE
Feat: paginación client-side de los listados

### DIFF
--- a/services/frontend/measurements.js
+++ b/services/frontend/measurements.js
@@ -1,10 +1,13 @@
 import { MONITOR, apiGet, apiPost, apiPut, apiDel } from './api.js';
-import { toast, openModal, closeModal, shortId, fmtDate, alertBadges } from './ui.js';
+import { toast, openModal, closeModal, shortId, fmtDate, alertBadges, renderList } from './ui.js';
 import { state, stationOptions } from './state.js';
+
+let measurementsPage = 1;
 
 export async function loadMeasurements(filters = {}) {
   const el = document.getElementById('measurements-list');
   el.innerHTML = '<div class="loading">Loading…</div>';
+  measurementsPage = 1;
 
   const params = new URLSearchParams();
   if (filters.stationName)  params.set('station_name', filters.stationName);
@@ -30,11 +33,16 @@ export async function loadMeasurements(filters = {}) {
 }
 
 function renderMeasurements(el, list) {
-  if (!list.length) {
-    el.innerHTML = '<div class="empty">No measurements found.</div>';
-    return;
-  }
-  el.innerHTML = `
+  renderList(el, list, {
+    emptyMessage: 'No measurements found.',
+    getPage: () => measurementsPage,
+    setPage: (page) => { measurementsPage = page; },
+    renderTable: measurementsTable,
+  });
+}
+
+function measurementsTable(list) {
+  return `
     <div class="table-wrap">
       <table>
         <thead>

--- a/services/frontend/stations.js
+++ b/services/frontend/stations.js
@@ -1,6 +1,8 @@
 import { CORE, apiGet, apiPost, apiPut, apiDel } from './api.js';
-import { toast, openModal, closeModal, shortId, fmtDate } from './ui.js';
+import { toast, openModal, closeModal, shortId, fmtDate, renderList } from './ui.js';
 import { state, userOptions } from './state.js';
+
+let stationsPage = 1;
 
 const CLIMATE_PROVIDERS = [
   { value: 'openweather', label: 'OpenWeather' },
@@ -21,6 +23,7 @@ export async function loadStations(filters = {}) {
   if (filters.createdFrom) params.set('created_from', filters.createdFrom);
   if (filters.createdTo)   params.set('created_to',   filters.createdTo);
 
+  stationsPage = 1;
   const qs = params.toString();
   try {
     const data = await apiGet(`${CORE}/stations${qs ? '?' + qs : ''}`);
@@ -40,11 +43,16 @@ export function currentStationFilters() {
 }
 
 function renderStations(el, list) {
-  if (!list.length) {
-    el.innerHTML = '<div class="empty">No stations found.</div>';
-    return;
-  }
-  el.innerHTML = `
+  renderList(el, list, {
+    emptyMessage: 'No stations found.',
+    getPage: () => stationsPage,
+    setPage: (page) => { stationsPage = page; },
+    renderTable: stationsTable,
+  });
+}
+
+function stationsTable(list) {
+  return `
     <div class="table-wrap">
       <table>
         <thead>

--- a/services/frontend/style.css
+++ b/services/frontend/style.css
@@ -95,6 +95,27 @@ body {
 .btn-danger    { background: none; color: var(--red); border-color: #5a1a1a; }
 .btn-danger:hover { background: #5a1a1a; }
 .btn-sm { padding: 0.2rem 0.55rem; font-size: 12px; }
+.btn:disabled { opacity: 0.4; cursor: default; pointer-events: none; }
+
+/* ── Pager ── */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0.75rem 0.25rem 0;
+}
+.page-input {
+  width: 3.2rem;
+  margin: 0 0.15rem;
+  padding: 0.15rem 0.35rem;
+  text-align: center;
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font: inherit;
+}
 
 /* ── Filters ── */
 .filters {

--- a/services/frontend/ui.js
+++ b/services/frontend/ui.js
@@ -53,5 +53,52 @@ export function alertBadges(alertTypes) {
   }).join('');
 }
 
+// ── Client-side pagination ──
+export const PAGE_SIZE = 10;
+
+// Renders a paginated list into `el`. Slices `list` into pages of PAGE_SIZE and
+// draws Prev/Next controls under the table. Changing page re-renders over the
+// already-loaded list — no refetch. `getPage`/`setPage` hold the per-list page.
+export function renderList(el, list, { renderTable, emptyMessage, getPage, setPage }) {
+  function draw() {
+    if (!list.length) {
+      el.innerHTML = `<div class="empty">${emptyMessage}</div>`;
+      return;
+    }
+    const pages = Math.max(1, Math.ceil(list.length / PAGE_SIZE));
+    const page  = Math.min(Math.max(1, getPage()), pages);
+    setPage(page);
+
+    const start = (page - 1) * PAGE_SIZE;
+    el.innerHTML = renderTable(list.slice(start, start + PAGE_SIZE)) + pager(page, pages);
+
+    const prev  = el.querySelector('[data-page="prev"]');
+    const next  = el.querySelector('[data-page="next"]');
+    const input = el.querySelector('[data-page="input"]');
+    if (prev) prev.addEventListener('click', () => { setPage(page - 1); draw(); });
+    if (next) next.addEventListener('click', () => { setPage(page + 1); draw(); });
+    if (input) input.addEventListener('change', () => {
+      const parsed = parseInt(input.value, 10);
+      const target = Number.isNaN(parsed) ? page : Math.min(Math.max(1, parsed), pages);
+      setPage(target);
+      draw();
+    });
+  }
+  draw();
+}
+
+function pager(page, pages) {
+  if (pages <= 1) return '';
+  return `
+    <div class="pager">
+      <button class="btn btn-sm btn-ghost" data-page="prev" ${page <= 1 ? 'disabled' : ''}>Prev</button>
+      <span class="dim mono">Page
+        <input class="page-input" type="number" min="1" max="${pages}" value="${page}" data-page="input" aria-label="Go to page">
+        of ${pages}</span>
+      <button class="btn btn-sm btn-ghost" data-page="next" ${page >= pages ? 'disabled' : ''}>Next</button>
+    </div>
+  `;
+}
+
 // Exposed for inline onclick handlers in dynamically generated HTML
 window.closeModal = closeModal;

--- a/services/frontend/users.js
+++ b/services/frontend/users.js
@@ -1,10 +1,13 @@
 import { CORE, apiGet, apiPost, apiPut, apiDel } from './api.js';
-import { toast, openModal, closeModal, shortId } from './ui.js';
+import { toast, openModal, closeModal, shortId, renderList } from './ui.js';
 import { state, stationOptions } from './state.js';
+
+let usersPage = 1;
 
 export async function loadUsers() {
   const el = document.getElementById('users-list');
   el.innerHTML = '<div class="loading">Loading…</div>';
+  usersPage = 1;
   try {
     const data = await apiGet(`${CORE}/users`);
     state.users = Array.isArray(data) ? data : (data?.data ?? []);
@@ -15,11 +18,16 @@ export async function loadUsers() {
 }
 
 function renderUsers(el, list) {
-  if (!list.length) {
-    el.innerHTML = '<div class="empty">No users found.</div>';
-    return;
-  }
-  el.innerHTML = `
+  renderList(el, list, {
+    emptyMessage: 'No users found.',
+    getPage: () => usersPage,
+    setPage: (page) => { usersPage = page; },
+    renderTable: usersTable,
+  });
+}
+
+function usersTable(list) {
+  return `
     <div class="table-wrap">
       <table>
         <thead>


### PR DESCRIPTION
 - Pagina en el navegador las tres tablas (measurements, stations, users) de a 10 filas, cortando el array ya cargado — sin tocar el backend ni refetchear al cambiar de página. Controles Prev/Next con indicador de página editable: un input permite saltar a una página puntual, clampeado a [1, total] para no pasarse ni ir a negativos. Cada carga (filtros, altas/ediciones/borrados, cambio de pestaña) resetea a página 1.