### PR TITLE
Feat: middleware de métricas HTTP por endpoint en Core y Monitor

### DIFF
--- a/services/core/app/Infrastructure/Http/Middleware/PrometheusHttpMiddleware.php
+++ b/services/core/app/Infrastructure/Http/Middleware/PrometheusHttpMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Prometheus\CollectorRegistry;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PrometheusHttpMiddleware
+{
+    public function __construct(
+        private readonly CollectorRegistry $registry,
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $start = microtime(true);
+
+        $response = $next($request);
+
+        $duration = microtime(true) - $start;
+        $method   = $request->method();
+        // Route template (e.g. "api/reports/current-temp/{stationId}"), never the
+        // concrete URL with IDs — keeps label cardinality bounded. Unmatched
+        // requests (404) have no route, so they share a fixed label value.
+        $route  = $request->route()?->uri() ?? 'unmatched';
+        $status = (string) $response->getStatusCode();
+
+        $this->registry
+            ->getOrRegisterCounter('http', 'requests_total', 'Total HTTP requests', ['method', 'route', 'status'])
+            ->inc([$method, $route, $status]);
+
+        $this->registry
+            ->getOrRegisterHistogram('http', 'request_duration_seconds', 'HTTP request duration in seconds', ['method', 'route'])
+            ->observe($duration, [$method, $route]);
+
+        return $response;
+    }
+}

--- a/services/core/bootstrap/app.php
+++ b/services/core/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Infrastructure\Http\Controllers\MetricsController;
+use App\Infrastructure\Http\Middleware\PrometheusHttpMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -18,7 +19,8 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        // Instruments request rate, latency and status per route template.
+        $middleware->appendToGroup('api', PrometheusHttpMiddleware::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/services/monitor/app/Infrastructure/Http/Middleware/PrometheusHttpMiddleware.php
+++ b/services/monitor/app/Infrastructure/Http/Middleware/PrometheusHttpMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Prometheus\CollectorRegistry;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PrometheusHttpMiddleware
+{
+    public function __construct(
+        private readonly CollectorRegistry $registry,
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $start = microtime(true);
+
+        $response = $next($request);
+
+        $duration = microtime(true) - $start;
+        $method   = $request->method();
+        // Route template (e.g. "api/reports/avg/day"), never the concrete URL
+        // with IDs — keeps label cardinality bounded. Unmatched requests (404)
+        // have no route, so they share a fixed label value.
+        $route  = $request->route()?->uri() ?? 'unmatched';
+        $status = (string) $response->getStatusCode();
+
+        $this->registry
+            ->getOrRegisterCounter('http', 'requests_total', 'Total HTTP requests', ['method', 'route', 'status'])
+            ->inc([$method, $route, $status]);
+
+        $this->registry
+            ->getOrRegisterHistogram('http', 'request_duration_seconds', 'HTTP request duration in seconds', ['method', 'route'])
+            ->observe($duration, [$method, $route]);
+
+        return $response;
+    }
+}

--- a/services/monitor/bootstrap/app.php
+++ b/services/monitor/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Infrastructure\Http\Controllers\MetricsController;
+use App\Infrastructure\Http\Middleware\PrometheusHttpMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -18,7 +19,8 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        // Instruments request rate, latency and status per route template.
+        $middleware->appendToGroup('api', PrometheusHttpMiddleware::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
- Instrumenta request rate, latencia y status por ruta en ambos servicios vía un PrometheusHttpMiddleware agregado al grupo `api`.
- Expone http_requests_total{method,route,status} y el histogram http_request_duration_seconds{method,route}.
- El label `route` usa el template de la ruta (ej. api/reports/current-temp/{stationId}), nunca la URL con IDs, para acotar la cardinalidad; las requests sin ruta matcheada caen en "unmatched".
- El middleware solo observa alrededor de $next y devuelve la respuesta intacta.