### PR TITLE
feat load tests avg reports

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -15,8 +15,8 @@ Tests de carga sobre los endpoints de reporte, corridos con [K6](https://k6.io/)
 Cada script corre con uno de tres perfiles, seleccionado con `-e PROFILE=`:
 
 - **`smoke`** (default): 3 VUs constantes, 30 s — verifica que el endpoint responde bien bajo carga mínima.
-- **`load`**: rampa 0 → 10 → 20 VUs, ~3 min — régimen normal.
-- **`stress`**: rampa 0 → 20 → 50 VUs sostenidos, ~4 min — dónde y cómo se degrada.
+- **`load`**: rampa 0 → 10 → 20 VUs, ~2 min — régimen normal.
+- **`stress`**: rampa 0 → 20 → 50 VUs sostenidos, ~2 min — dónde y cómo se degrada. Duración pensada para poder mostrarlo en vivo en la presentación.
 
 Todos los perfiles validan los mismos thresholds (definidos en `lib/profiles.js`): `http_req_duration p95 < 500ms` y `http_req_failed < 1%`. Si no se cumplen, K6 termina con exit code ≠ 0.
 

--- a/tests/load/avg-day.js
+++ b/tests/load/avg-day.js
@@ -1,0 +1,16 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { buildOptions, MONITOR_BASE_URL, STATION_ID } from './lib/profiles.js';
+
+export const options = buildOptions();
+
+export default function () {
+    const response = http.get(`${MONITOR_BASE_URL}/api/reports/avg/day?station_id=${STATION_ID}`);
+
+    check(response, {
+        'status is 200': (result) => result.status === 200,
+        'body has a numeric averageTemperature': (result) => typeof result.json('averageTemperature') === 'number',
+    });
+
+    sleep(1);
+}

--- a/tests/load/avg-week.js
+++ b/tests/load/avg-week.js
@@ -1,0 +1,16 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { buildOptions, MONITOR_BASE_URL, STATION_ID } from './lib/profiles.js';
+
+export const options = buildOptions();
+
+export default function () {
+    const response = http.get(`${MONITOR_BASE_URL}/api/reports/avg/week?station_id=${STATION_ID}`);
+
+    check(response, {
+        'status is 200': (result) => result.status === 200,
+        'body has a numeric averageTemperature': (result) => typeof result.json('averageTemperature') === 'number',
+    });
+
+    sleep(1);
+}

--- a/tests/load/lib/profiles.js
+++ b/tests/load/lib/profiles.js
@@ -13,19 +13,19 @@ const PROFILES = {
         executor: 'ramping-vus',
         startVUs: 0,
         stages: [
-            { duration: '30s', target: 10 },
-            { duration: '2m', target: 20 },
-            { duration: '30s', target: 0 },
+            { duration: '20s', target: 10 },
+            { duration: '80s', target: 20 },
+            { duration: '20s', target: 0 },
         ],
     },
     stress: {
         executor: 'ramping-vus',
         startVUs: 0,
         stages: [
-            { duration: '30s', target: 20 },
-            { duration: '1m', target: 50 },
-            { duration: '2m', target: 50 },
-            { duration: '30s', target: 0 },
+            { duration: '20s', target: 20 },
+            { duration: '30s', target: 50 },
+            { duration: '50s', target: 50 },
+            { duration: '20s', target: 0 },
         ],
     },
 };


### PR DESCRIPTION
- T2 y T3 siguen el patrón de current-temp, reusando los perfiles y thresholds compartidos. El check valida averageTemperature.

- Se acortan los perfiles load y stress a 2 minutos, manteniendo la forma rampa → meseta → bajada, para poder correr los tests en vivo durante la presentación. Con las latencias medidas (~12ms) la meseta sigue metiendo ~4200 requests por corrida de stress, suficiente para el régimen sostenido.